### PR TITLE
feat: add production routes and observability to wrangler.toml

### DIFF
--- a/backend-rust/wrangler.toml
+++ b/backend-rust/wrangler.toml
@@ -50,6 +50,8 @@ enabled = true
 # Preview environment for PR deployments
 # Worker name is overridden via --name flag at deploy time
 [env.preview]
+workers_dev = true
+routes = []
 vars = { ENVIRONMENT = "preview" }
 
 # Test KV namespaces (shared across PRs, isolated from production)


### PR DESCRIPTION
## Summary

- Move route configuration from Cloudflare dashboard into `wrangler.toml` (infrastructure-as-code)
- Add `api.recordwell.app/health/*` route for the new healthcheck endpoints (merged in #118)
- Enable observability traces alongside existing logs

## Routes

| Pattern | Purpose |
|---------|---------|
| `api.recordwell.app/auth/opaque/*` | Existing OPAQUE auth endpoints |
| `api.recordwell.app/health/*` | New healthcheck endpoints |

## Test Plan

- [ ] CI passes
- [ ] After merge, verify `wrangler deploy` adopts the routes (check Cloudflare dashboard)
- [ ] Verify healthcheck endpoints respond on `api.recordwell.app`

## Summary by Sourcery

Configure production Cloudflare Worker routes and enable tracing observability in wrangler.toml.

New Features:
- Define production HTTP routes for auth and health endpoints directly in wrangler.toml for Wrangler-managed deployment.

Enhancements:
- Enable observability traces in addition to existing logs for the production Worker.