### PR TITLE
refactor: replace string errors with BackupValidationError enum (#143)

### DIFF
--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Models/Backup/BackupError.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Models/Backup/BackupError.swift
@@ -30,7 +30,7 @@ enum BackupError: Error, LocalizedError, Equatable {
     case fileOperationFailed(String)
 
     /// The backup file failed JSON Schema validation
-    case schemaValidationFailed([String])
+    case schemaValidationFailed([BackupValidationError])
 
     var errorDescription: String? {
         switch self {
@@ -53,7 +53,7 @@ enum BackupError: Error, LocalizedError, Equatable {
         case let .fileOperationFailed(reason):
             "File operation failed: \(reason)"
         case let .schemaValidationFailed(errors):
-            "Backup file is invalid: \(errors.joined(separator: "; "))"
+            "Backup file is invalid: \(errors.map(\.description).joined(separator: "; "))"
         }
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Backup/BackupFileService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Backup/BackupFileService.swift
@@ -281,7 +281,10 @@ final class BackupFileService: BackupFileServiceProtocol, @unchecked Sendable {
         // Validate against schema BEFORE decoding
         let validationResult = schemaValidator.validate(jsonData: data)
         if !validationResult.isValid {
-            logger.error("Schema validation failed: \(validationResult.errors.joined(separator: ", "))")
+            logger
+                .error(
+                    "Schema validation failed: \(validationResult.errors.map(\.description).joined(separator: ", "))"
+                )
             throw BackupError.schemaValidationFailed(validationResult.errors)
         }
 

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Backup/BackupSchemaValidator.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Backup/BackupSchemaValidator.swift
@@ -1,17 +1,59 @@
 import Foundation
 import JSONSchema
 
+/// Typed validation errors emitted by `BackupSchemaValidator`.
+enum BackupValidationError: Equatable, CustomStringConvertible {
+    /// JSON could not be parsed
+    case malformedJSON(String)
+
+    /// JSON parsed but couldn't be decoded for schema validation
+    case jsonDecodingFailed(String)
+
+    /// Schema resource not bundled — fail closed
+    case schemaUnavailable
+
+    /// DoS: nesting depth exceeded
+    case nestingDepthExceeded(actual: Int, max: Int)
+
+    /// DoS: array size exceeded
+    case arraySizeExceeded(actual: Int, max: Int)
+
+    /// A JSON Schema keyword failed
+    case schemaViolation(keyword: String, path: String, message: String)
+
+    var description: String {
+        switch self {
+        case let .malformedJSON(detail):
+            "Invalid JSON: \(detail)"
+        case let .jsonDecodingFailed(detail):
+            "Failed to decode JSON: \(detail)"
+        case .schemaUnavailable:
+            "Backup schema not available; validation cannot proceed"
+        case let .nestingDepthExceeded(actual, max):
+            "JSON nesting depth (\(actual)) exceeds maximum allowed (\(max))"
+        case let .arraySizeExceeded(actual, max):
+            "Array size (\(actual)) exceeds maximum allowed (\(max))"
+        case let .schemaViolation(keyword, path, message):
+            if message.isEmpty {
+                "Validation failed at \(path) (keyword: \(keyword))"
+            } else {
+                "\(message) at \(path)"
+            }
+        }
+    }
+}
+
 /// Result of validating JSON against the backup schema
 struct BackupValidationResult: Equatable {
     /// Whether the JSON is valid according to the schema
     let isValid: Bool
 
     /// List of validation errors (empty if valid)
-    let errors: [String]
+    let errors: [BackupValidationError]
 
     static let valid = BackupValidationResult(isValid: true, errors: [])
 
-    static func invalid(_ errors: [String]) -> BackupValidationResult {
+    static func invalid(_ errors: [BackupValidationError]) -> BackupValidationResult {
         BackupValidationResult(isValid: false, errors: errors)
     }
 }
@@ -84,21 +126,20 @@ final class BackupSchemaValidator: BackupSchemaValidatorProtocol, @unchecked Sen
             jsonObject = try JSONSerialization.jsonObject(with: jsonData, options: [])
         } catch {
             logger.logError(error, context: "BackupSchemaValidator.validate")
-            return .invalid(["Invalid JSON: \(error.localizedDescription)"])
+            return .invalid([.malformedJSON(error.localizedDescription)])
         }
 
         // Step 2: Check DoS limits before schema validation
         let dosResult = checkDoSLimits(jsonObject)
         if !dosResult.isValid {
-            logger.notice("DoS limit exceeded: \(dosResult.errors.joined(separator: ", "))")
+            logger.notice("DoS limit exceeded: \(dosResult.errors.map(\.description).joined(separator: ", "))")
             return dosResult
         }
 
         // Step 3: Validate against schema (fail closed if unavailable)
         guard let schema else {
-            let errorMessage = "Backup schema not available; validation cannot proceed"
-            logger.error("\(errorMessage)")
-            return .invalid([errorMessage])
+            logger.error("Backup schema not available; validation cannot proceed")
+            return .invalid([.schemaUnavailable])
         }
 
         // Convert to JSONValue for schema validation
@@ -107,7 +148,7 @@ final class BackupSchemaValidator: BackupSchemaValidatorProtocol, @unchecked Sen
             jsonValue = try JSONDecoder().decode(JSONSchema.JSONValue.self, from: jsonData)
         } catch {
             logger.logError(error, context: "BackupSchemaValidator.validate")
-            return .invalid(["Failed to decode JSON: \(error.localizedDescription)"])
+            return .invalid([.jsonDecodingFailed(error.localizedDescription)])
         }
 
         // Validate against schema
@@ -118,7 +159,7 @@ final class BackupSchemaValidator: BackupSchemaValidatorProtocol, @unchecked Sen
             return .valid
         } else {
             let errors = Self.flattenErrors(result.errors ?? [])
-            logger.notice("Schema validation failed: \(errors.joined(separator: ", "))")
+            logger.notice("Schema validation failed: \(errors.map(\.description).joined(separator: ", "))")
             return .invalid(errors)
         }
     }
@@ -154,18 +195,18 @@ final class BackupSchemaValidator: BackupSchemaValidatorProtocol, @unchecked Sen
     }
 
     private func checkDoSLimits(_ jsonObject: Any) -> BackupValidationResult {
-        var errors: [String] = []
+        var errors: [BackupValidationError] = []
 
         // Check nesting depth
         let depth = calculateDepth(jsonObject)
         if depth > maxNestingDepth {
-            errors.append("JSON nesting depth (\(depth)) exceeds maximum allowed (\(maxNestingDepth))")
+            errors.append(.nestingDepthExceeded(actual: depth, max: maxNestingDepth))
         }
 
         // Check array sizes
         let maxFoundArraySize = findMaxArraySize(jsonObject)
         if maxFoundArraySize > maxArraySize {
-            errors.append("Array size (\(maxFoundArraySize)) exceeds maximum allowed (\(maxArraySize))")
+            errors.append(.arraySizeExceeded(actual: maxFoundArraySize, max: maxArraySize))
         }
 
         return errors.isEmpty ? .valid : .invalid(errors)
@@ -234,17 +275,16 @@ final class BackupSchemaValidator: BackupSchemaValidatorProtocol, @unchecked Sen
         return maxSize
     }
 
-    /// Flatten nested validation errors into simple string messages
-    private static func flattenErrors(_ errors: [ValidationError]) -> [String] {
-        var result: [String] = []
+    /// Flatten nested validation errors into typed `BackupValidationError` values
+    private static func flattenErrors(_ errors: [ValidationError]) -> [BackupValidationError] {
+        var result: [BackupValidationError] = []
 
         for error in errors {
-            let message = if error.message.isEmpty {
-                "Validation failed at \(error.instanceLocation) (keyword: \(error.keyword))"
-            } else {
-                "\(error.message) at \(error.instanceLocation)"
-            }
-            result.append(message)
+            result.append(.schemaViolation(
+                keyword: error.keyword,
+                path: error.instanceLocation.description,
+                message: error.message
+            ))
 
             // Recursively flatten nested errors
             if let nested = error.errors {

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Backup/BackupSchemaValidator.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Backup/BackupSchemaValidator.swift
@@ -12,8 +12,9 @@ enum BackupValidationError: Equatable, CustomStringConvertible {
     /// Schema resource not bundled — fail closed
     case schemaUnavailable
 
-    /// DoS: nesting depth exceeded
-    case nestingDepthExceeded(actual: Int, max: Int)
+    /// DoS: nesting depth exceeded. `observed` is the first depth found exceeding
+    /// `max`, not necessarily the true maximum (due to early-exit optimization).
+    case nestingDepthExceeded(observed: Int, max: Int)
 
     /// DoS: array size exceeded
     case arraySizeExceeded(actual: Int, max: Int)
@@ -29,8 +30,8 @@ enum BackupValidationError: Equatable, CustomStringConvertible {
             "Failed to decode JSON: \(detail)"
         case .schemaUnavailable:
             "Backup schema not available; validation cannot proceed"
-        case let .nestingDepthExceeded(actual, max):
-            "JSON nesting depth (\(actual)) exceeds maximum allowed (\(max))"
+        case let .nestingDepthExceeded(observed, max):
+            "JSON nesting depth (\(observed)) exceeds maximum allowed (\(max))"
         case let .arraySizeExceeded(actual, max):
             "Array size (\(actual)) exceeds maximum allowed (\(max))"
         case let .schemaViolation(keyword, path, message):
@@ -200,7 +201,7 @@ final class BackupSchemaValidator: BackupSchemaValidatorProtocol, @unchecked Sen
         // Check nesting depth
         let depth = calculateDepth(jsonObject)
         if depth > maxNestingDepth {
-            errors.append(.nestingDepthExceeded(actual: depth, max: maxNestingDepth))
+            errors.append(.nestingDepthExceeded(observed: depth, max: maxNestingDepth))
         }
 
         // Check array sizes

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Backup/BackupSchemaValidatorDoSTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Backup/BackupSchemaValidatorDoSTests.swift
@@ -138,8 +138,8 @@ struct BackupSchemaValidatorDoSTests {
         let result = validator.validate(jsonData: deeplyNested)
         #expect(!result.isValid)
         let hasTypedError = result.errors.contains {
-            if case let .nestingDepthExceeded(actual, max) = $0 {
-                return actual == 6 && max == 5
+            if case let .nestingDepthExceeded(observed, max) = $0 {
+                return observed == 6 && max == 5
             }
             return false
         }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Backup/BackupSchemaValidatorDoSTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Backup/BackupSchemaValidatorDoSTests.swift
@@ -19,7 +19,9 @@ struct BackupSchemaValidatorDoSTests {
 
         let result = validator.validate(jsonData: deeplyNested)
         #expect(!result.isValid)
-        #expect(result.errors.contains { $0.contains("depth") || $0.contains("nesting") })
+        #expect(result.errors.contains {
+            if case .nestingDepthExceeded = $0 { true } else { false }
+        })
     }
 
     @Test("Exceeding max array size fails validation")
@@ -32,7 +34,9 @@ struct BackupSchemaValidatorDoSTests {
 
         let result = validator.validate(jsonData: json)
         #expect(!result.isValid)
-        #expect(result.errors.contains { $0.contains("array") || $0.contains("size") })
+        #expect(result.errors.contains {
+            if case .arraySizeExceeded = $0 { true } else { false }
+        })
     }
 
     // MARK: - Edge Cases for DoS Limits
@@ -46,7 +50,9 @@ struct BackupSchemaValidatorDoSTests {
 
         let result = validator.validate(jsonData: json)
         // Will fail schema validation but should pass DoS checks
-        #expect(!result.errors.contains { $0.contains("array") && $0.contains("size") })
+        #expect(!result.errors.contains {
+            if case .arraySizeExceeded = $0 { true } else { false }
+        })
     }
 
     @Test("Empty dictionaries pass DoS validation")
@@ -58,7 +64,9 @@ struct BackupSchemaValidatorDoSTests {
 
         let result = validator.validate(jsonData: json)
         // Will fail schema validation but should pass DoS checks
-        #expect(!result.errors.contains { $0.contains("depth") || $0.contains("nesting") })
+        #expect(!result.errors.contains {
+            if case .nestingDepthExceeded = $0 { true } else { false }
+        })
     }
 
     @Test("Primitive root value passes depth check")
@@ -68,7 +76,9 @@ struct BackupSchemaValidatorDoSTests {
 
         let result = validator.validate(jsonData: json)
         // Will fail schema validation but should pass DoS checks
-        #expect(!result.errors.contains { $0.contains("depth") || $0.contains("nesting") })
+        #expect(!result.errors.contains {
+            if case .nestingDepthExceeded = $0 { true } else { false }
+        })
     }
 
     @Test("Deeply nested arrays trigger depth limit")
@@ -80,7 +90,9 @@ struct BackupSchemaValidatorDoSTests {
 
         let result = validator.validate(jsonData: json)
         #expect(!result.isValid)
-        #expect(result.errors.contains { $0.contains("depth") || $0.contains("nesting") })
+        #expect(result.errors.contains {
+            if case .nestingDepthExceeded = $0 { true } else { false }
+        })
     }
 
     @Test("Nested array sizes are checked")
@@ -92,7 +104,9 @@ struct BackupSchemaValidatorDoSTests {
 
         let result = validator.validate(jsonData: json)
         #expect(!result.isValid)
-        #expect(result.errors.contains { $0.contains("array") || $0.contains("size") })
+        #expect(result.errors.contains {
+            if case .arraySizeExceeded = $0 { true } else { false }
+        })
     }
 
     @Test("Within limits passes DoS checks")
@@ -104,6 +118,48 @@ struct BackupSchemaValidatorDoSTests {
 
         let result = validator.validate(jsonData: json)
         // Will fail schema validation but should pass DoS checks
-        #expect(!result.errors.contains { $0.contains("depth") || $0.contains("array") })
+        #expect(!result.errors.contains {
+            if case .nestingDepthExceeded = $0 { true } else { false }
+        })
+        #expect(!result.errors.contains {
+            if case .arraySizeExceeded = $0 { true } else { false }
+        })
+    }
+
+    // MARK: - Associated Value Tests
+
+    @Test("Nesting depth error carries actual and max values")
+    func nestingDepthErrorCarriesValues() {
+        let validator = BackupSchemaValidator.forTesting(maxNestingDepth: 5)
+        let deeplyNested = Data("""
+        {"a":{"b":{"c":{"d":{"e":{"f":{"g":"too deep"}}}}}}}
+        """.utf8)
+
+        let result = validator.validate(jsonData: deeplyNested)
+        #expect(!result.isValid)
+        let hasTypedError = result.errors.contains {
+            if case let .nestingDepthExceeded(actual, max) = $0 {
+                return actual == 6 && max == 5
+            }
+            return false
+        }
+        #expect(hasTypedError)
+    }
+
+    @Test("Array size error carries actual and max values")
+    func arraySizeErrorCarriesValues() throws {
+        let validator = BackupSchemaValidator.forTesting(maxArraySize: 10)
+        let largeArray = Array(repeating: "item", count: 20)
+        let json = try JSONSerialization.data(withJSONObject: ["items": largeArray])
+
+        let result = validator.validate(jsonData: json)
+        #expect(!result.isValid)
+        let hasTypedError = result.errors.contains {
+            if case let .arraySizeExceeded(actual, max) = $0 {
+                return actual == 20 && max == 10
+            }
+            return false
+        }
+        #expect(hasTypedError)
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Backup/BackupSchemaValidatorTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Backup/BackupSchemaValidatorTests.swift
@@ -220,8 +220,9 @@ struct BackupSchemaValidatorTests {
 
         let result = validator.validate(jsonData: invalidJSON)
         #expect(!result.isValid)
-        #expect(result.errors
-            .contains { $0.contains("generator") || $0.contains("checksum") || $0.contains("required") })
+        #expect(result.errors.contains {
+            if case .schemaViolation = $0 { true } else { false }
+        })
     }
 
     @Test("Wrong formatName fails validation")
@@ -281,7 +282,9 @@ struct BackupSchemaValidatorTests {
 
         let result = validator.validate(jsonData: malformedJSON)
         #expect(!result.isValid)
-        #expect(result.errors.contains { $0.lowercased().contains("json") || $0.lowercased().contains("parse") })
+        #expect(result.errors.contains {
+            if case .malformedJSON = $0 { true } else { false }
+        })
     }
 
     // MARK: - Schema Version


### PR DESCRIPTION
## Summary

- Defines `BackupValidationError` enum with 6 typed cases (`malformedJSON`, `jsonDecodingFailed`, `schemaUnavailable`, `nestingDepthExceeded`, `arraySizeExceeded`, `schemaViolation`) replacing free-form `[String]` errors
- Updates `BackupValidationResult.errors`, `BackupError.schemaValidationFailed`, and `BackupFileService` to use the typed enum
- Migrates all test assertions from brittle substring matching to enum pattern-matching
- Adds 2 new tests verifying associated values carry correct actual/max data

## Test plan

- [x] Full test suite passes (1533/1536, 3 skipped, 0 failures)
- [x] Coverage check passes (84.78% overall, all files meet thresholds)
- [x] Pre-commit hooks pass (SwiftFormat, SwiftLint, all 22 checks)
- [x] `BackupSchemaValidator.swift` coverage at 87.68% (above 85% threshold)
- [x] `BackupError.swift` coverage at 92.00%

Closes #143

## Summary by Sourcery

Introduce a typed backup schema validation error model and propagate it through validation, error handling, and tests.

New Features:
- Add the BackupValidationError enum to represent structured backup schema validation failures with associated values.

Enhancements:
- Update BackupSchemaValidator and BackupFileService to use BackupValidationError instead of free-form string error messages, improving logging and error propagation.

Tests:
- Refactor backup schema validator tests to assert against BackupValidationError cases instead of string contents, and add tests verifying associated values for DoS limit errors.