### PR TITLE
fix(attachments): filename truth, content-driven service, title cap (#149)

### DIFF
--- a/ios/FamilyMedicalApp/FamilyMedicalApp.xcodeproj/project.pbxproj
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp.xcodeproj/project.pbxproj
@@ -13,8 +13,8 @@
 		D445F7DE2EFB435900E07F78 /* Clibsodium in Frameworks */ = {isa = PBXBuildFile; productRef = D445F7DD2EFB435900E07F78 /* Clibsodium */; };
 		D445F7E02EFB435900E07F78 /* Sodium in Frameworks */ = {isa = PBXBuildFile; productRef = D445F7DF2EFB435900E07F78 /* Sodium */; };
 		D49F98D32F2A9E5B00E436A0 /* OpaqueSwift in Frameworks */ = {isa = PBXBuildFile; productRef = D49F98D22F2A9E5B00E436A0 /* OpaqueSwift */; };
-		D4SCHEMA012F3000000099999 /* JSONSchema in Frameworks */ = {isa = PBXBuildFile; productRef = D4SCHEMA002F3000000099999 /* JSONSchema */; };
 		D4ISSRPT022F4007070003CC /* IssueReporting in Frameworks */ = {isa = PBXBuildFile; productRef = D4ISSRPT012F4007070002BB /* IssueReporting */; };
+		D4SCHEMA012F3000000099999 /* JSONSchema in Frameworks */ = {isa = PBXBuildFile; productRef = D4SCHEMA002F3000000099999 /* JSONSchema */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -758,15 +758,15 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = OpaqueSwift;
 		};
-		D4SCHEMA002F3000000099999 /* JSONSchema */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = D4SCHEMA032F3000000099999 /* XCRemoteSwiftPackageReference "swift-json-schema" */;
-			productName = JSONSchema;
-		};
 		D4ISSRPT012F4007070002BB /* IssueReporting */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = D4XCTDYN002F4007070001AA /* XCRemoteSwiftPackageReference "xctest-dynamic-overlay" */;
 			productName = IssueReporting;
+		};
+		D4SCHEMA002F3000000099999 /* JSONSchema */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D4SCHEMA032F3000000099999 /* XCRemoteSwiftPackageReference "swift-json-schema" */;
+			productName = JSONSchema;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Extensions/String+FilenameExtension.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Extensions/String+FilenameExtension.swift
@@ -13,14 +13,28 @@ extension String {
     /// is nil — the helper uses `fallback` if provided, otherwise returns the receiver unchanged.
     /// Callers that must produce a file with *some* extension (e.g. for the iOS share sheet) pass
     /// `fallback: "bin"`; callers producing a user-visible display title pass `fallback: nil`.
+    ///
+    /// The helper is idempotent for the canonical extension: calling it on a string
+    /// that already ends with `.<canonicalExtension>` (or `.<fallback>` when the
+    /// fallback path is taken) returns the receiver unchanged, so callers can run
+    /// the helper safely on strings that may or may not already carry the extension.
     func appendingCanonicalExtension(forMimeType mimeType: String, fallback: String?) -> String {
+        let extToAppend: String
         if let type = UTType(mimeType: mimeType),
-           let ext = type.preferredFilenameExtension {
-            return "\(self).\(ext)"
+           let preferred = type.preferredFilenameExtension {
+            extToAppend = preferred
+        } else if let fallback {
+            extToAppend = fallback
+        } else {
+            return self
         }
-        if let fallback {
-            return "\(self).\(fallback)"
+        // Idempotence guard: if the receiver already ends with the extension we
+        // would append, return it unchanged so the helper does not produce
+        // "file.pdf.pdf" when called on a base that already carries the canonical
+        // extension for the detected MIME.
+        if hasSuffix(".\(extToAppend)") {
+            return self
         }
-        return self
+        return "\(self).\(extToAppend)"
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Extensions/String+FilenameExtension.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Extensions/String+FilenameExtension.swift
@@ -1,0 +1,26 @@
+import Foundation
+import UniformTypeIdentifiers
+
+extension String {
+    /// Append the canonical filename extension for `mimeType` to the receiver.
+    ///
+    /// Apple's UTType registry owns the mapping (`UTType(mimeType:)?.preferredFilenameExtension`),
+    /// so the result agrees with whatever iOS would produce for that MIME — e.g. `image/jpeg` →
+    /// `jpeg`, `image/heic` → `heic`, `application/pdf` → `pdf`.
+    ///
+    /// When the MIME cannot be mapped to a concrete extension — unrecognized types, synthetic
+    /// `dyn.*` placeholder types (e.g. `image/unknown`), or types whose `preferredFilenameExtension`
+    /// is nil — the helper uses `fallback` if provided, otherwise returns the receiver unchanged.
+    /// Callers that must produce a file with *some* extension (e.g. for the iOS share sheet) pass
+    /// `fallback: "bin"`; callers producing a user-visible display title pass `fallback: nil`.
+    func appendingCanonicalExtension(forMimeType mimeType: String, fallback: String?) -> String {
+        if let type = UTType(mimeType: mimeType),
+           let ext = type.preferredFilenameExtension {
+            return "\(self).\(ext)"
+        }
+        if let fallback {
+            return "\(self).\(fallback)"
+        }
+        return self
+    }
+}

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Models/ModelError+UserFacing.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Models/ModelError+UserFacing.swift
@@ -53,8 +53,8 @@ extension ModelError {
         // Document errors
         case let .documentTooLarge(maxSizeMB):
             return "File is too large. Maximum size is \(maxSizeMB) MB."
-        case let .unsupportedMimeType(mimeType):
-            return "File type '\(mimeType)' is not supported. Please use JPEG, PNG, or PDF."
+        case .unsupportedContent:
+            return "File type is not supported. Please use JPEG, PNG, HEIC, or PDF."
         case let .documentLimitExceeded(max):
             return "Maximum of \(max) attachments per record reached."
         case .documentNotFound:

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Models/ModelError+UserFacing.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Models/ModelError+UserFacing.swift
@@ -54,7 +54,7 @@ extension ModelError {
         case let .documentTooLarge(maxSizeMB):
             return "File is too large. Maximum size is \(maxSizeMB) MB."
         case .unsupportedContent:
-            return "File type is not supported. Please use JPEG, PNG, HEIC, or PDF."
+            return "File type is not supported. Please use a supported image format (JPEG, PNG, HEIC, etc.) or PDF."
         case let .documentLimitExceeded(max):
             return "Maximum of \(max) attachments per record reached."
         case .documentNotFound:

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Models/ModelErrors.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Models/ModelErrors.swift
@@ -77,7 +77,7 @@ enum ModelError: LocalizedError, Equatable {
         case let .documentTooLarge(maxSizeMB):
             "File exceeds maximum size of \(maxSizeMB) MB"
         case .unsupportedContent:
-            "File is not a supported image or PDF"
+            "File is not a supported image format or PDF"
         case let .documentLimitExceeded(max):
             "Maximum of \(max) attachments per record exceeded"
         case let .documentNotFound(documentId):

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Models/ModelErrors.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Models/ModelErrors.swift
@@ -22,7 +22,7 @@ enum ModelError: LocalizedError, Equatable {
     // MARK: - Document Errors
 
     case documentTooLarge(maxSizeMB: Int)
-    case unsupportedMimeType(mimeType: String)
+    case unsupportedContent
     case documentLimitExceeded(max: Int)
     case documentNotFound(documentId: UUID? = nil)
     case documentContentCorrupted
@@ -76,8 +76,8 @@ enum ModelError: LocalizedError, Equatable {
         // Document errors
         case let .documentTooLarge(maxSizeMB):
             "File exceeds maximum size of \(maxSizeMB) MB"
-        case let .unsupportedMimeType(mimeType):
-            "File type '\(mimeType)' is not supported. Please use JPEG, PNG, or PDF"
+        case .unsupportedContent:
+            "File is not a supported image or PDF"
         case let .documentLimitExceeded(max):
             "Maximum of \(max) attachments per record exceeded"
         case let .documentNotFound(documentId):

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Models/Records/DocumentReferenceRecord.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Models/Records/DocumentReferenceRecord.swift
@@ -6,12 +6,18 @@ struct DocumentReferenceRecord: MedicalRecordContent {
     static let displayName: String = "Document"
     static let iconSystemName: String = "doc"
 
-    /// Maximum permitted length for `title` at ingestion points. Titles longer than
-    /// this are silently truncated by `normalizedTitle(_:)` rather than rejected —
-    /// the common ingestion path is `url.lastPathComponent` from the document picker,
-    /// which the user cannot easily shorten. 255 matches filesystem filename conventions
-    /// (NTFS, APFS, HFS+) and is wide enough for any reasonable medical document name
-    /// while bounding Core Data row size, backup JSON size, and UI render cost.
+    /// Maximum permitted length for `title`, measured in Swift `Character`s
+    /// (extended grapheme clusters). Titles longer than this are silently truncated
+    /// by the `title` setter — the common ingestion path is `url.lastPathComponent`
+    /// from the document picker, which the user cannot easily shorten, so a throw
+    /// would be a dead-end UX.
+    ///
+    /// This is a *loose* upper bound on the underlying UTF-8 byte count rather
+    /// than an exact one: 255 grapheme clusters can be up to roughly 1.5KB for
+    /// pathological Unicode (e.g. family emoji with ZWJ sequences). That is still
+    /// well within the threat model, which is adversarial bloat of the encrypted
+    /// Core Data store, the backup JSON, and the SwiftUI render path — not exact
+    /// filesystem conformance.
     static let titleMaxLength = 255
 
     /// Truncate `raw` to at most `titleMaxLength` characters. Use this at every
@@ -21,8 +27,21 @@ struct DocumentReferenceRecord: MedicalRecordContent {
         String(raw.prefix(titleMaxLength))
     }
 
-    // Type-specific fields
-    var title: String
+    // MARK: - Type-specific fields
+
+    /// Backing storage for `title`. Never mutate this directly — assign through
+    /// the computed `title` setter so every mutation routes through
+    /// `normalizedTitle(_:)` and the 255-grapheme invariant is preserved.
+    private var _title: String
+
+    /// User-visible document title. Every assignment is automatically truncated
+    /// to `titleMaxLength` grapheme clusters by the setter; no caller anywhere
+    /// in the module can bypass the cap.
+    var title: String {
+        get { _title }
+        set { _title = Self.normalizedTitle(newValue) }
+    }
+
     var documentType: String?
     var mimeType: String
     var fileSize: Int
@@ -47,7 +66,7 @@ struct DocumentReferenceRecord: MedicalRecordContent {
         tags: [String] = [],
         unknownFields: [String: JSONValue] = [:]
     ) {
-        self.title = Self.normalizedTitle(title)
+        self._title = Self.normalizedTitle(title)
         self.documentType = documentType
         self.mimeType = mimeType
         self.fileSize = fileSize
@@ -68,7 +87,7 @@ struct DocumentReferenceRecord: MedicalRecordContent {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        title = try Self.normalizedTitle(container.decode(String.self, forKey: .title))
+        _title = try Self.normalizedTitle(container.decode(String.self, forKey: .title))
         documentType = try container.decodeIfPresent(String.self, forKey: .documentType)
         mimeType = try container.decode(String.self, forKey: .mimeType)
         fileSize = try container.decode(Int.self, forKey: .fileSize)

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Models/Records/DocumentReferenceRecord.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Models/Records/DocumentReferenceRecord.swift
@@ -6,6 +6,21 @@ struct DocumentReferenceRecord: MedicalRecordContent {
     static let displayName: String = "Document"
     static let iconSystemName: String = "doc"
 
+    /// Maximum permitted length for `title` at ingestion points. Titles longer than
+    /// this are silently truncated by `normalizedTitle(_:)` rather than rejected —
+    /// the common ingestion path is `url.lastPathComponent` from the document picker,
+    /// which the user cannot easily shorten. 255 matches filesystem filename conventions
+    /// (NTFS, APFS, HFS+) and is wide enough for any reasonable medical document name
+    /// while bounding Core Data row size, backup JSON size, and UI render cost.
+    static let titleMaxLength = 255
+
+    /// Truncate `raw` to at most `titleMaxLength` characters. Use this at every
+    /// ingestion point (init, decode, in-app edit) so an adversarial filename cannot
+    /// bloat the encrypted store or the backup file.
+    static func normalizedTitle(_ raw: String) -> String {
+        String(raw.prefix(titleMaxLength))
+    }
+
     // Type-specific fields
     var title: String
     var documentType: String?
@@ -32,7 +47,7 @@ struct DocumentReferenceRecord: MedicalRecordContent {
         tags: [String] = [],
         unknownFields: [String: JSONValue] = [:]
     ) {
-        self.title = title
+        self.title = Self.normalizedTitle(title)
         self.documentType = documentType
         self.mimeType = mimeType
         self.fileSize = fileSize
@@ -53,7 +68,7 @@ struct DocumentReferenceRecord: MedicalRecordContent {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        title = try container.decode(String.self, forKey: .title)
+        title = try Self.normalizedTitle(container.decode(String.self, forKey: .title))
         documentType = try container.decodeIfPresent(String.self, forKey: .documentType)
         mimeType = try container.decode(String.self, forKey: .mimeType)
         fileSize = try container.decode(Int.self, forKey: .fileSize)

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentBlobService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentBlobService.swift
@@ -1,6 +1,5 @@
 import CryptoKit
 import Foundation
-import ImageIO
 import PDFKit
 
 /// Storage of encrypted document blobs on disk, keyed by HMAC-SHA256 of plaintext (keyed with FMK).
@@ -84,10 +83,10 @@ final class DocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sendabl
         primaryKey: SymmetricKey
     ) async throws -> StoredBlob {
         let start = ContinuousClock.now
-        logger.entry("store")
         do {
             let fmk = try fmkService.retrieveFMK(familyMemberID: personId.uuidString, primaryKey: primaryKey)
             let processed = try process(plaintext: plaintext)
+            logger.entry("store", "detectedMime=\(processed.detectedMimeType) plaintextSize=\(plaintext.count)")
             let hmac = Data(HMAC<SHA256>.authenticationCode(for: processed.data, using: fmk))
 
             let encryptedSize: Int
@@ -184,15 +183,21 @@ final class DocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sendabl
             }
             return ProcessedBlob(data: plaintext, thumbnailData: nil, detectedMimeType: "application/pdf")
         }
-        if Self.isImageContent(plaintext) {
-            let detectedMime = try imageProcessor.validateImage(plaintext)
-            let thumbnail = try imageProcessor.generateThumbnail(
-                plaintext,
-                maxDimension: Self.thumbnailDimension
-            )
-            return ProcessedBlob(data: plaintext, thumbnailData: thumbnail, detectedMimeType: detectedMime)
+        // Single CGImageSource pass: validateImage is the only image probe.
+        // Failures here mean the bytes are neither a recognized image format
+        // nor a recognizable container — re-throw as unsupportedContent so the
+        // error type matches the post-PDF "not a known content type" branch.
+        let detectedMime: String
+        do {
+            detectedMime = try imageProcessor.validateImage(plaintext)
+        } catch {
+            throw ModelError.unsupportedContent
         }
-        throw ModelError.unsupportedContent
+        let thumbnail = try imageProcessor.generateThumbnail(
+            plaintext,
+            maxDimension: Self.thumbnailDimension
+        )
+        return ProcessedBlob(data: plaintext, thumbnailData: thumbnail, detectedMimeType: detectedMime)
     }
 
     /// PDF files begin with `%PDF-` (25 50 44 46 2D). Cheap byte-prefix check so we can
@@ -201,14 +206,5 @@ final class DocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sendabl
         let magic: [UInt8] = [0x25, 0x50, 0x44, 0x46, 0x2D]
         guard data.count >= magic.count else { return false }
         return data.prefix(magic.count).elementsEqual(magic)
-    }
-
-    /// Uses Apple's CGImageSource to detect whether `data` is a valid image.
-    /// Checks that CGImageSource can identify the data type, not just create a lazy source.
-    private static func isImageContent(_ data: Data) -> Bool {
-        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
-            return false
-        }
-        return CGImageSourceGetType(source) != nil
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentBlobService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentBlobService.swift
@@ -86,7 +86,7 @@ final class DocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sendabl
         do {
             let fmk = try fmkService.retrieveFMK(familyMemberID: personId.uuidString, primaryKey: primaryKey)
             let processed = try process(plaintext: plaintext)
-            logger.entry("store", "detectedMime=\(processed.detectedMimeType) plaintextSize=\(plaintext.count)")
+            logger.entry("store", "detectedMime=\(processed.detectedMimeType), plaintextSize=\(plaintext.count)")
             let hmac = Data(HMAC<SHA256>.authenticationCode(for: processed.data, using: fmk))
 
             let encryptedSize: Int
@@ -191,6 +191,7 @@ final class DocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sendabl
         do {
             detectedMime = try imageProcessor.validateImage(plaintext)
         } catch {
+            logger.debug("validateImage rejected bytes: \(error)")
             throw ModelError.unsupportedContent
         }
         let thumbnail = try imageProcessor.generateThumbnail(

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentBlobService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentBlobService.swift
@@ -9,10 +9,11 @@ import PDFKit
 /// not re-upload the blob. HMAC keying with the Family Member Key prevents rainbow-table attacks
 /// on known content.
 protocol DocumentBlobServiceProtocol: Sendable {
-    /// Encrypt, store, and return storage metadata for a plaintext blob.
+    /// Encrypt, store, and return storage metadata for a plaintext blob. The content type
+    /// is detected from the bytes themselves (PDF via `%PDF-` magic bytes, images via
+    /// CGImageSource); callers do not pass a MIME hint.
     func store(
         plaintext: Data,
-        mimeType: String,
         personId: UUID,
         primaryKey: SymmetricKey
     ) async throws -> DocumentBlobService.StoredBlob
@@ -79,15 +80,14 @@ final class DocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sendabl
 
     func store(
         plaintext: Data,
-        mimeType: String,
         personId: UUID,
         primaryKey: SymmetricKey
     ) async throws -> StoredBlob {
         let start = ContinuousClock.now
-        logger.entry("store", "mimeType=\(mimeType)")
+        logger.entry("store")
         do {
             let fmk = try fmkService.retrieveFMK(familyMemberID: personId.uuidString, primaryKey: primaryKey)
-            let processed = try process(plaintext: plaintext, mimeType: mimeType)
+            let processed = try process(plaintext: plaintext)
             let hmac = Data(HMAC<SHA256>.authenticationCode(for: processed.data, using: fmk))
 
             let encryptedSize: Int
@@ -165,41 +165,47 @@ final class DocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sendabl
 
     // MARK: - Private
 
-    /// Returns `(data, thumbnail, detectedMimeType)`.
+    /// Detect content type from the bytes and process accordingly.
     ///
-    /// - Images: validated via CGImageSource, original bytes stored as-is, JPEG thumbnail generated.
-    /// - PDFs: validated via PDFDocument, stored as-is.
-    /// - Other: rejected.
-    private func process(plaintext: Data, mimeType: String) throws -> ProcessedBlob {
-        // Check PDF first — CGImageSource accepts PDF data, so the image probe
-        // must not run when the caller already declared application/pdf.
-        if mimeType.lowercased() == "application/pdf" {
-            guard plaintext.count <= Self.maxFileSizeBytes else {
-                throw ModelError.documentTooLarge(maxSizeMB: Self.maxFileSizeBytes / (1_024 * 1_024))
-            }
+    /// - PDFs: detected by `%PDF-` magic bytes, then validated via `PDFDocument(data:)`,
+    ///   stored as-is with no thumbnail.
+    /// - Images: detected via CGImageSource, original bytes stored as-is, JPEG thumbnail generated.
+    /// - Everything else: rejected.
+    ///
+    /// PDF is checked before images because CGImageSource also accepts PDF data and would
+    /// otherwise mis-route PDFs into the image path.
+    private func process(plaintext: Data) throws -> ProcessedBlob {
+        guard plaintext.count <= Self.maxFileSizeBytes else {
+            throw ModelError.documentTooLarge(maxSizeMB: Self.maxFileSizeBytes / (1_024 * 1_024))
+        }
+        if Self.isPDFContent(plaintext) {
             guard PDFDocument(data: plaintext) != nil else {
                 throw ModelError.imageProcessingFailed(reason: "File content is not a valid PDF")
             }
             return ProcessedBlob(data: plaintext, thumbnailData: nil, detectedMimeType: "application/pdf")
-        } else if mimeType.lowercased().hasPrefix("image/") || isImageContent(plaintext) {
-            guard plaintext.count <= Self.maxFileSizeBytes else {
-                throw ModelError.documentTooLarge(maxSizeMB: Self.maxFileSizeBytes / (1_024 * 1_024))
-            }
+        }
+        if Self.isImageContent(plaintext) {
             let detectedMime = try imageProcessor.validateImage(plaintext)
             let thumbnail = try imageProcessor.generateThumbnail(
                 plaintext,
                 maxDimension: Self.thumbnailDimension
             )
             return ProcessedBlob(data: plaintext, thumbnailData: thumbnail, detectedMimeType: detectedMime)
-        } else {
-            throw ModelError.unsupportedMimeType(mimeType: mimeType)
         }
+        throw ModelError.unsupportedContent
     }
 
-    /// Uses Apple's CGImageSource to detect whether `data` is a valid image,
-    /// regardless of the declared MIME type. Replaces hand-rolled magic-byte checks.
+    /// PDF files begin with `%PDF-` (25 50 44 46 2D). Cheap byte-prefix check so we can
+    /// avoid the heavier `PDFDocument(data:)` parse for non-PDF inputs.
+    private static func isPDFContent(_ data: Data) -> Bool {
+        let magic: [UInt8] = [0x25, 0x50, 0x44, 0x46, 0x2D]
+        guard data.count >= magic.count else { return false }
+        return data.prefix(magic.count).elementsEqual(magic)
+    }
+
+    /// Uses Apple's CGImageSource to detect whether `data` is a valid image.
     /// Checks that CGImageSource can identify the data type, not just create a lazy source.
-    private func isImageContent(_ data: Data) -> Bool {
+    private static func isImageContent(_ data: Data) -> Bool {
         guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
             return false
         }

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/ViewModels/Documents/DocumentPickerViewModel.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/ViewModels/Documents/DocumentPickerViewModel.swift
@@ -60,6 +60,12 @@ final class DocumentPickerViewModel {
     /// Maximum drafts per record.
     static let maxPerRecord: Int = 5
 
+    /// Sentinel MIME hint passed to `DocumentBlobService.store` when the caller has not
+    /// sniffed the bytes yet. The service runs `CGImageSource` detection regardless of
+    /// the hint and returns the real MIME as `stored.detectedMimeType` — this string is
+    /// only a marker meaning "I don't know, please detect."
+    private static let unknownMimeHint = "image/unknown"
+
     // MARK: - Dependencies
 
     @ObservationIgnored private let blobService: DocumentBlobServiceProtocol
@@ -121,11 +127,14 @@ final class DocumentPickerViewModel {
         isLoading = true
         errorMessage = nil
         do {
+            // UIImagePickerController hands us an already-decoded UIImage, so the camera's
+            // original encoded bytes are not recoverable here; we re-encode to JPEG.
+            // See Issue #160 for the AVCapturePhotoOutput rework that would lift this.
             guard let imageData = image.jpegData(compressionQuality: 0.9) else {
                 throw ModelError.imageProcessingFailed(reason: "Could not convert image to JPEG")
             }
-            let fileName = "Photo_\(Self.formatTimestamp(dateProvider())).jpg"
-            try await storeAndAppend(plaintext: imageData, fileName: fileName, mimeType: "image/jpeg")
+            let baseName = "Photo_\(Self.formatTimestamp(dateProvider()))"
+            try await storeAndAppendGenerated(plaintext: imageData, baseName: baseName, mimeType: "image/jpeg")
         } catch let error as ModelError {
             errorMessage = error.userFacingMessage
             logger.logError(error, context: "DocumentPickerViewModel.addFromCamera")
@@ -183,10 +192,8 @@ final class DocumentPickerViewModel {
                 logger.info("Skipping photo item - could not load data")
                 return
             }
-            // Pass "image/unknown" — DocumentBlobService will detect the real MIME
-            // via CGImageSource in process().
-            let fileName = "Photo_\(Self.formatTimestamp(dateProvider())).jpg"
-            try await storeAndAppend(plaintext: data, fileName: fileName, mimeType: "image/unknown")
+            let baseName = "Photo_\(Self.formatTimestamp(dateProvider()))"
+            try await storeAndAppendGenerated(plaintext: data, baseName: baseName, mimeType: Self.unknownMimeHint)
         } catch let error as ModelError {
             errorMessage = error.userFacingMessage
             logger.logError(error, context: "DocumentPickerViewModel.addFromPhotoLibrary")
@@ -216,6 +223,7 @@ final class DocumentPickerViewModel {
         }
     }
 
+    /// URL document-picker path — uses the user's chosen filename verbatim.
     private func storeAndAppend(plaintext: Data, fileName: String, mimeType: String) async throws {
         let stored = try await blobService.store(
             plaintext: plaintext,
@@ -223,12 +231,36 @@ final class DocumentPickerViewModel {
             personId: personId,
             primaryKey: primaryKey
         )
-        let actualMime = stored.detectedMimeType
+        appendDraft(stored: stored, fileSize: plaintext.count, title: fileName)
+    }
+
+    /// Camera and photo-library paths — synthesizes the title from `baseName` plus the
+    /// canonical extension for the MIME that `DocumentBlobService` detected, so the title
+    /// agrees with the actually-stored bytes instead of whatever the caller guessed.
+    private func storeAndAppendGenerated(plaintext: Data, baseName: String, mimeType: String) async throws {
+        let stored = try await blobService.store(
+            plaintext: plaintext,
+            mimeType: mimeType,
+            personId: personId,
+            primaryKey: primaryKey
+        )
+        let title = baseName.appendingCanonicalExtension(
+            forMimeType: stored.detectedMimeType,
+            fallback: nil
+        )
+        appendDraft(stored: stored, fileSize: plaintext.count, title: title)
+    }
+
+    private func appendDraft(
+        stored: DocumentBlobService.StoredBlob,
+        fileSize: Int,
+        title: String
+    ) {
         let doc = DocumentReferenceRecord(
-            title: fileName,
+            title: title,
             documentType: nil,
-            mimeType: actualMime,
-            fileSize: plaintext.count,
+            mimeType: stored.detectedMimeType,
+            fileSize: fileSize,
             contentHMAC: stored.contentHMAC,
             thumbnailData: stored.thumbnailData,
             sourceRecordId: sourceRecordId,

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/ViewModels/Documents/DocumentPickerViewModel.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/ViewModels/Documents/DocumentPickerViewModel.swift
@@ -4,7 +4,6 @@ import Observation
 import PhotosUI
 import SwiftUI
 import UIKit
-import UniformTypeIdentifiers
 
 /// ViewModel for selecting and managing DocumentReferenceRecord drafts in a medical record form.
 ///
@@ -60,11 +59,17 @@ final class DocumentPickerViewModel {
     /// Maximum drafts per record.
     static let maxPerRecord: Int = 5
 
-    /// Sentinel MIME hint passed to `DocumentBlobService.store` when the caller has not
-    /// sniffed the bytes yet. The service runs `CGImageSource` detection regardless of
-    /// the hint and returns the real MIME as `stored.detectedMimeType` — this string is
-    /// only a marker meaning "I don't know, please detect."
-    private static let unknownMimeHint = "image/unknown"
+    // MARK: - Types
+
+    /// How to derive the title of a draft relative to the detected MIME of the blob.
+    private enum TitleStrategy {
+        /// Use this literal string as the title regardless of detected MIME. For the
+        /// URL document-picker path, where the user already picked a real filename.
+        case verbatim(String)
+        /// Append the canonical extension for the detected MIME to this base. For the
+        /// camera and photo-library paths, where the filename is generated.
+        case derived(baseName: String)
+    }
 
     // MARK: - Dependencies
 
@@ -134,7 +139,7 @@ final class DocumentPickerViewModel {
                 throw ModelError.imageProcessingFailed(reason: "Could not convert image to JPEG")
             }
             let baseName = "Photo_\(Self.formatTimestamp(dateProvider()))"
-            try await storeAndAppendGenerated(plaintext: imageData, baseName: baseName, mimeType: "image/jpeg")
+            try await storeAndAppend(plaintext: imageData, title: .derived(baseName: baseName))
         } catch let error as ModelError {
             errorMessage = error.userFacingMessage
             logger.logError(error, context: "DocumentPickerViewModel.addFromCamera")
@@ -193,7 +198,7 @@ final class DocumentPickerViewModel {
                 return
             }
             let baseName = "Photo_\(Self.formatTimestamp(dateProvider()))"
-            try await storeAndAppendGenerated(plaintext: data, baseName: baseName, mimeType: Self.unknownMimeHint)
+            try await storeAndAppend(plaintext: data, title: .derived(baseName: baseName))
         } catch let error as ModelError {
             errorMessage = error.userFacingMessage
             logger.logError(error, context: "DocumentPickerViewModel.addFromPhotoLibrary")
@@ -211,9 +216,7 @@ final class DocumentPickerViewModel {
                 }
             }
             let data = try Data(contentsOf: url)
-            let fileName = url.lastPathComponent
-            let mimeType = Self.mimeType(forPathExtension: url.pathExtension)
-            try await storeAndAppend(plaintext: data, fileName: fileName, mimeType: mimeType)
+            try await storeAndAppend(plaintext: data, title: .verbatim(url.lastPathComponent))
         } catch let error as ModelError {
             errorMessage = error.userFacingMessage
             logger.logError(error, context: "DocumentPickerViewModel.addFromDocumentPicker")
@@ -223,44 +226,23 @@ final class DocumentPickerViewModel {
         }
     }
 
-    /// URL document-picker path — uses the user's chosen filename verbatim.
-    private func storeAndAppend(plaintext: Data, fileName: String, mimeType: String) async throws {
+    private func storeAndAppend(plaintext: Data, title: TitleStrategy) async throws {
         let stored = try await blobService.store(
             plaintext: plaintext,
-            mimeType: mimeType,
             personId: personId,
             primaryKey: primaryKey
         )
-        appendDraft(stored: stored, fileSize: plaintext.count, title: fileName)
-    }
-
-    /// Camera and photo-library paths — synthesizes the title from `baseName` plus the
-    /// canonical extension for the MIME that `DocumentBlobService` detected, so the title
-    /// agrees with the actually-stored bytes instead of whatever the caller guessed.
-    private func storeAndAppendGenerated(plaintext: Data, baseName: String, mimeType: String) async throws {
-        let stored = try await blobService.store(
-            plaintext: plaintext,
-            mimeType: mimeType,
-            personId: personId,
-            primaryKey: primaryKey
-        )
-        let title = baseName.appendingCanonicalExtension(
-            forMimeType: stored.detectedMimeType,
-            fallback: nil
-        )
-        appendDraft(stored: stored, fileSize: plaintext.count, title: title)
-    }
-
-    private func appendDraft(
-        stored: DocumentBlobService.StoredBlob,
-        fileSize: Int,
-        title: String
-    ) {
+        let finalTitle: String = switch title {
+        case let .verbatim(name):
+            name
+        case let .derived(baseName):
+            baseName.appendingCanonicalExtension(forMimeType: stored.detectedMimeType, fallback: nil)
+        }
         let doc = DocumentReferenceRecord(
-            title: title,
+            title: finalTitle,
             documentType: nil,
             mimeType: stored.detectedMimeType,
-            fileSize: fileSize,
+            fileSize: plaintext.count,
             contentHMAC: stored.contentHMAC,
             thumbnailData: stored.thumbnailData,
             sourceRecordId: sourceRecordId,
@@ -276,9 +258,5 @@ final class DocumentPickerViewModel {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
         return formatter.string(from: date)
-    }
-
-    private static func mimeType(forPathExtension ext: String) -> String {
-        UTType(filenameExtension: ext)?.preferredMIMEType ?? "application/octet-stream"
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/ViewModels/Documents/DocumentViewerViewModel.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/ViewModels/Documents/DocumentViewerViewModel.swift
@@ -1,7 +1,6 @@
 import CryptoKit
 import Foundation
 import Observation
-import UniformTypeIdentifiers
 
 /// ViewModel for viewing a DocumentReferenceRecord's decrypted content in full-screen.
 ///
@@ -162,7 +161,6 @@ final class DocumentViewerViewModel {
     /// Zero user input in the filesystem path — prevents path traversal by construction.
     private var sanitizedFileName: String {
         let hexPrefix = document.contentHMAC.prefix(8).map { String(format: "%02x", $0) }.joined()
-        let ext = UTType(mimeType: document.mimeType)?.preferredFilenameExtension ?? "bin"
-        return "\(hexPrefix).\(ext)"
+        return hexPrefix.appendingCanonicalExtension(forMimeType: document.mimeType, fallback: "bin")
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Extensions/StringFilenameExtensionTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Extensions/StringFilenameExtensionTests.swift
@@ -65,6 +65,20 @@ struct StringFilenameExtensionTests {
         #expect(result == "Photo_20260410_143045")
     }
 
+    @Test
+    func appendingExtension_baseAlreadyHasCanonicalExtension_doesNotDoubleAppend() {
+        let result = "lab_results.pdf"
+            .appendingCanonicalExtension(forMimeType: "application/pdf", fallback: nil)
+        #expect(result == "lab_results.pdf")
+    }
+
+    @Test
+    func appendingExtension_baseHasCanonicalExtensionWithBinFallback_doesNotDoubleAppend() {
+        let result = "scan.png"
+            .appendingCanonicalExtension(forMimeType: "image/png", fallback: "bin")
+        #expect(result == "scan.png")
+    }
+
     // MARK: - fallback: "bin" (share-sheet export mode)
 
     @Test

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Extensions/StringFilenameExtensionTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Extensions/StringFilenameExtensionTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+@testable import FamilyMedicalApp
+
+/// Unit tests for `String.appendingCanonicalExtension(forMimeType:fallback:)`.
+///
+/// The helper derives a filename from a base name and a detected MIME type. It's used
+/// by `DocumentPickerViewModel` to label incoming attachments with the canonical extension
+/// for their actual stored format, and by `DocumentViewerViewModel` to produce a temp-file
+/// name for the share-sheet export flow (where the file must have *some* extension so iOS
+/// picks a sensible default app).
+struct StringFilenameExtensionTests {
+    // MARK: - fallback: nil (display-title mode)
+
+    @Test
+    func appendingExtension_pngMime_appendsPng() {
+        let result = "Photo_20260410_143045"
+            .appendingCanonicalExtension(forMimeType: "image/png", fallback: nil)
+        #expect(result == "Photo_20260410_143045.png")
+    }
+
+    @Test
+    func appendingExtension_heicMime_appendsHeic() {
+        let result = "Photo_20260410_143045"
+            .appendingCanonicalExtension(forMimeType: "image/heic", fallback: nil)
+        #expect(result == "Photo_20260410_143045.heic")
+    }
+
+    @Test
+    func appendingExtension_jpegMime_appendsCanonicalJpegExtension() {
+        // UTType.jpeg.preferredFilenameExtension is "jpeg", not "jpg".
+        let result = "Photo_20260410_143045"
+            .appendingCanonicalExtension(forMimeType: "image/jpeg", fallback: nil)
+        #expect(result == "Photo_20260410_143045.jpeg")
+    }
+
+    @Test
+    func appendingExtension_pdfMime_appendsPdf() {
+        let result = "lab_results"
+            .appendingCanonicalExtension(forMimeType: "application/pdf", fallback: nil)
+        #expect(result == "lab_results.pdf")
+    }
+
+    @Test
+    func appendingExtension_gifMime_appendsGif() {
+        let result = "anim"
+            .appendingCanonicalExtension(forMimeType: "image/gif", fallback: nil)
+        #expect(result == "anim.gif")
+    }
+
+    @Test
+    func appendingExtension_unrecognizedMime_nilFallback_returnsBaseUnchanged() {
+        let result = "Photo_20260410_143045"
+            .appendingCanonicalExtension(forMimeType: "application/x-nonexistent", fallback: nil)
+        #expect(result == "Photo_20260410_143045")
+    }
+
+    @Test
+    func appendingExtension_syntheticDynamicMime_nilFallback_returnsBaseUnchanged() {
+        // `image/unknown` resolves to a synthetic `dyn.*` UTType whose
+        // preferredFilenameExtension is nil. The helper must fall through cleanly rather
+        // than producing `Photo_….dyn.xxxxx`.
+        let result = "Photo_20260410_143045"
+            .appendingCanonicalExtension(forMimeType: "image/unknown", fallback: nil)
+        #expect(result == "Photo_20260410_143045")
+    }
+
+    // MARK: - fallback: "bin" (share-sheet export mode)
+
+    @Test
+    func appendingExtension_pngMime_binFallback_stillAppendsPng() {
+        let result = "abc12345"
+            .appendingCanonicalExtension(forMimeType: "image/png", fallback: "bin")
+        #expect(result == "abc12345.png")
+    }
+
+    @Test
+    func appendingExtension_unrecognizedMime_binFallback_appendsBin() {
+        let result = "abc12345"
+            .appendingCanonicalExtension(forMimeType: "application/x-nonexistent", fallback: "bin")
+        #expect(result == "abc12345.bin")
+    }
+
+    @Test
+    func appendingExtension_syntheticDynamicMime_binFallback_appendsBin() {
+        let result = "abc12345"
+            .appendingCanonicalExtension(forMimeType: "image/unknown", fallback: "bin")
+        #expect(result == "abc12345.bin")
+    }
+}

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Extensions/StringFilenameExtensionTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Extensions/StringFilenameExtensionTests.swift
@@ -73,10 +73,13 @@ struct StringFilenameExtensionTests {
     }
 
     @Test
-    func appendingExtension_baseHasCanonicalExtensionWithBinFallback_doesNotDoubleAppend() {
-        let result = "scan.png"
-            .appendingCanonicalExtension(forMimeType: "image/png", fallback: "bin")
-        #expect(result == "scan.png")
+    func appendingExtension_baseHasFallbackExtension_doesNotDoubleAppend() {
+        // Uses an unrecognized MIME so the canonical-extension branch falls
+        // through to the fallback branch — this exercises the fallback path's
+        // idempotence guard, not the canonical-extension path's.
+        let result = "archive.bin"
+            .appendingCanonicalExtension(forMimeType: "application/x-unknown-xyz", fallback: "bin")
+        #expect(result == "archive.bin")
     }
 
     // MARK: - fallback: "bin" (share-sheet export mode)

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockDocumentBlobService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockDocumentBlobService.swift
@@ -10,7 +10,6 @@ import Foundation
 final class MockDocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sendable {
     struct StoreCall {
         let plaintext: Data
-        let mimeType: String
         let personId: UUID
     }
 
@@ -24,13 +23,17 @@ final class MockDocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sen
     var retrieveError: Error?
     var deleteError: Error?
 
+    /// MIME the mock reports as `detectedMimeType` in the synthesized StoredBlob when
+    /// no explicit `storeResult` is set. Defaults to `image/jpeg` so existing fixtures
+    /// that just check "was store called" still get a plausible result.
+    var detectedMimeStub: String = "image/jpeg"
+
     func store(
         plaintext: Data,
-        mimeType: String,
         personId: UUID,
         primaryKey _: SymmetricKey
     ) async throws -> DocumentBlobService.StoredBlob {
-        storeCalls.append(StoreCall(plaintext: plaintext, mimeType: mimeType, personId: personId))
+        storeCalls.append(StoreCall(plaintext: plaintext, personId: personId))
         if let storeError {
             throw storeError
         }
@@ -38,12 +41,12 @@ final class MockDocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sen
             return storeResult
         }
         let hmac = Data(SHA256.hash(data: plaintext))
-        let thumbnail: Data? = mimeType.lowercased().hasPrefix("image/") ? Data([0xAA, 0xBB]) : nil
+        let thumbnail: Data? = detectedMimeStub.lowercased().hasPrefix("image/") ? Data([0xAA, 0xBB]) : nil
         return DocumentBlobService.StoredBlob(
             contentHMAC: hmac,
             encryptedSize: plaintext.count,
             thumbnailData: thumbnail,
-            detectedMimeType: mimeType
+            detectedMimeType: detectedMimeStub
         )
     }
 

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Models/Records/DocumentReferenceRecordTitleLengthTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Models/Records/DocumentReferenceRecordTitleLengthTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+@testable import FamilyMedicalApp
+
+@Suite("DocumentReferenceRecord title length limit")
+struct DocumentReferenceRecordTitleLengthTests {
+    // MARK: - normalizedTitle helper
+
+    @Test
+    func normalizedTitle_shortInput_returnsUnchanged() {
+        let input = "Lab Results 2026-01-15.pdf"
+        let result = DocumentReferenceRecord.normalizedTitle(input)
+        #expect(result == input)
+    }
+
+    @Test
+    func normalizedTitle_exactlyMaxLength_returnsUnchanged() {
+        let input = String(repeating: "a", count: DocumentReferenceRecord.titleMaxLength)
+        let result = DocumentReferenceRecord.normalizedTitle(input)
+        #expect(result.count == DocumentReferenceRecord.titleMaxLength)
+        #expect(result == input)
+    }
+
+    @Test
+    func normalizedTitle_oneOverMaxLength_truncatesToMax() {
+        let input = String(repeating: "a", count: DocumentReferenceRecord.titleMaxLength + 1)
+        let result = DocumentReferenceRecord.normalizedTitle(input)
+        #expect(result.count == DocumentReferenceRecord.titleMaxLength)
+    }
+
+    @Test
+    func normalizedTitle_wildlyOverMax_truncatesToMax() {
+        let input = String(repeating: "x", count: 10_000)
+        let result = DocumentReferenceRecord.normalizedTitle(input)
+        #expect(result.count == DocumentReferenceRecord.titleMaxLength)
+    }
+
+    @Test
+    func normalizedTitle_empty_returnsEmpty() {
+        #expect(DocumentReferenceRecord.normalizedTitle("").isEmpty)
+    }
+
+    // MARK: - init(title:) normalizes
+
+    @Test
+    func init_titleOverMaxLength_truncatesToMax() {
+        let overLong = String(repeating: "b", count: DocumentReferenceRecord.titleMaxLength + 100)
+        let record = DocumentReferenceRecord(
+            title: overLong,
+            mimeType: "application/pdf",
+            fileSize: 1_024,
+            contentHMAC: Data(repeating: 0x01, count: 32)
+        )
+        #expect(record.title.count == DocumentReferenceRecord.titleMaxLength)
+    }
+
+    @Test
+    func init_titleUnderMaxLength_keepsTitleUnchanged() {
+        let record = DocumentReferenceRecord(
+            title: "short.pdf",
+            mimeType: "application/pdf",
+            fileSize: 1_024,
+            contentHMAC: Data(repeating: 0x01, count: 32)
+        )
+        #expect(record.title == "short.pdf")
+    }
+
+    // MARK: - init(from: Decoder) normalizes
+
+    @Test
+    func decode_titleOverMaxLength_truncatesToMax() throws {
+        let overLong = String(repeating: "c", count: DocumentReferenceRecord.titleMaxLength + 50)
+        let json = """
+        {
+          "title": "\(overLong)",
+          "mimeType": "application/pdf",
+          "fileSize": 1024,
+          "contentHMAC": "\(Data(repeating: 0x01, count: 32).base64EncodedString())",
+          "tags": []
+        }
+        """
+        let decoded = try JSONDecoder().decode(
+            DocumentReferenceRecord.self,
+            from: Data(json.utf8)
+        )
+        #expect(decoded.title.count == DocumentReferenceRecord.titleMaxLength)
+    }
+
+    @Test
+    func decode_titleUnderMaxLength_keepsTitleUnchanged() throws {
+        let json = """
+        {
+          "title": "normal.pdf",
+          "mimeType": "application/pdf",
+          "fileSize": 1024,
+          "contentHMAC": "\(Data(repeating: 0x01, count: 32).base64EncodedString())",
+          "tags": []
+        }
+        """
+        let decoded = try JSONDecoder().decode(
+            DocumentReferenceRecord.self,
+            from: Data(json.utf8)
+        )
+        #expect(decoded.title == "normal.pdf")
+    }
+}

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Attachment/DocumentBlobServiceTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Attachment/DocumentBlobServiceTests.swift
@@ -1,6 +1,7 @@
 import CryptoKit
 import Foundation
 import Testing
+import UIKit
 @testable import FamilyMedicalApp
 
 @Suite("DocumentBlobService Tests")
@@ -43,8 +44,20 @@ struct DocumentBlobServiceTests {
         )
     }
 
+    /// Real, CGImageSource-decodable JPEG bytes. The service uses content-based detection
+    /// via CGImageSource, so test fixtures cannot rely on a hand-rolled SOI marker — the
+    /// sniffer would reject it. A 10×10 UIGraphicsImageRenderer frame is cheap to build
+    /// and always yields a valid JPEG header plus body.
     private static func makeJPEG() -> Data {
-        Data([0xFF, 0xD8, 0xFF, 0xE0] + Array(repeating: UInt8(0), count: 128))
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: 10, height: 10))
+        let image = renderer.image { ctx in
+            UIColor.blue.setFill()
+            ctx.fill(CGRect(x: 0, y: 0, width: 10, height: 10))
+        }
+        guard let data = image.jpegData(compressionQuality: 0.8) else {
+            fatalError("UIGraphicsImageRenderer failed to produce JPEG bytes")
+        }
+        return data
     }
 
     /// Minimal valid PDF that PDFDocument(data:) accepts.
@@ -75,7 +88,6 @@ struct DocumentBlobServiceTests {
         let ctx = Self.makeFixture()
         let result = try await ctx.service.store(
             plaintext: Self.makeJPEG(),
-            mimeType: "image/jpeg",
             personId: ctx.personId,
             primaryKey: ctx.primaryKey
         )
@@ -86,12 +98,11 @@ struct DocumentBlobServiceTests {
         #expect(ctx.fileStorage.storeCalls.first?.contentHMAC == result.contentHMAC)
     }
 
-    @Test("store generates thumbnail for image MIME types")
+    @Test("store generates thumbnail for image content")
     func storeGeneratesThumbnailForImages() async throws {
         let ctx = Self.makeFixture()
         let result = try await ctx.service.store(
             plaintext: Self.makeJPEG(),
-            mimeType: "image/jpeg",
             personId: ctx.personId,
             primaryKey: ctx.primaryKey
         )
@@ -105,7 +116,6 @@ struct DocumentBlobServiceTests {
         let ctx = Self.makeFixture()
         let result = try await ctx.service.store(
             plaintext: Self.makePDF(),
-            mimeType: "application/pdf",
             personId: ctx.personId,
             primaryKey: ctx.primaryKey
         )
@@ -114,13 +124,14 @@ struct DocumentBlobServiceTests {
         #expect(ctx.imageProcessor.thumbnailCalls.isEmpty)
     }
 
-    @Test("store rejects unsupported MIME types")
-    func storeRejectsUnsupportedMimeType() async throws {
+    @Test("store rejects content that is neither a valid image nor a PDF")
+    func storeRejectsUnsupportedContent() async throws {
         let ctx = Self.makeFixture()
+        // Bytes that do not start with %PDF- and that CGImageSource cannot identify.
+        let arbitrary = Data([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07])
         await #expect(throws: ModelError.self) {
             _ = try await ctx.service.store(
-                plaintext: Data([0x00]),
-                mimeType: "application/exe",
+                plaintext: arbitrary,
                 personId: ctx.personId,
                 primaryKey: ctx.primaryKey
             )
@@ -134,7 +145,6 @@ struct DocumentBlobServiceTests {
         await #expect(throws: ModelError.self) {
             _ = try await ctx.service.store(
                 plaintext: tooBig,
-                mimeType: "image/jpeg",
                 personId: ctx.personId,
                 primaryKey: ctx.primaryKey
             )
@@ -148,7 +158,6 @@ struct DocumentBlobServiceTests {
         await #expect(throws: ModelError.self) {
             _ = try await ctx.service.store(
                 plaintext: tooBig,
-                mimeType: "application/pdf",
                 personId: ctx.personId,
                 primaryKey: ctx.primaryKey
             )
@@ -161,7 +170,6 @@ struct DocumentBlobServiceTests {
         let originalData = Self.makeJPEG()
         _ = try await ctx.service.store(
             plaintext: originalData,
-            mimeType: "image/jpeg",
             personId: ctx.personId,
             primaryKey: ctx.primaryKey
         )
@@ -176,7 +184,6 @@ struct DocumentBlobServiceTests {
         // First store
         let first = try await ctx.service.store(
             plaintext: Self.makePDF(),
-            mimeType: "application/pdf",
             personId: ctx.personId,
             primaryKey: ctx.primaryKey
         )
@@ -184,7 +191,6 @@ struct DocumentBlobServiceTests {
         // Second store of identical bytes — should dedupe (no second write)
         _ = try await ctx.service.store(
             plaintext: Self.makePDF(),
-            mimeType: "application/pdf",
             personId: ctx.personId,
             primaryKey: ctx.primaryKey
         )
@@ -196,32 +202,17 @@ struct DocumentBlobServiceTests {
         #expect(first.contentHMAC == ctx.fileStorage.storeCalls.first?.contentHMAC)
     }
 
-    @Test("store validates image via CGImageSource path for image/* MIME")
-    func storeValidatesImageForImageMime() async throws {
+    @Test("store validates image via CGImageSource and reports the detected MIME")
+    func storeValidatesImageViaCGImageSource() async throws {
         let ctx = Self.makeFixture()
         ctx.imageProcessor.validateResult = "image/heic"
-        _ = try await ctx.service.store(
+        let result = try await ctx.service.store(
             plaintext: Self.makeJPEG(),
-            mimeType: "image/heic",
             personId: ctx.personId,
             primaryKey: ctx.primaryKey
         )
         #expect(ctx.imageProcessor.validateCalls.count == 1)
-    }
-
-    @Test("store routes image data with wrong MIME to image path via CGImageSource probe")
-    func storeDetectsImageDataEvenWithWrongMime() async throws {
-        let ctx = Self.makeFixture()
-        // JPEG bytes but mimeType says "application/octet-stream"
-        // isImageContent() will detect valid image data via CGImageSource and route to image path
-        _ = try await ctx.service.store(
-            plaintext: Self.makeJPEG(),
-            mimeType: "application/octet-stream",
-            personId: ctx.personId,
-            primaryKey: ctx.primaryKey
-        )
-        #expect(ctx.imageProcessor.validateCalls.count == 1)
-        #expect(ctx.imageProcessor.thumbnailCalls.count == 1)
+        #expect(result.detectedMimeType == "image/heic")
     }
 
     // MARK: - retrieve
@@ -232,7 +223,6 @@ struct DocumentBlobServiceTests {
         let original = Self.makeJPEG()
         let stored = try await ctx.service.store(
             plaintext: original,
-            mimeType: "image/jpeg",
             personId: ctx.personId,
             primaryKey: ctx.primaryKey
         )

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Attachment/DocumentBlobServiceTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Attachment/DocumentBlobServiceTests.swift
@@ -127,7 +127,12 @@ struct DocumentBlobServiceTests {
     @Test("store rejects content that is neither a valid image nor a PDF")
     func storeRejectsUnsupportedContent() async throws {
         let ctx = Self.makeFixture()
-        // Bytes that do not start with %PDF- and that CGImageSource cannot identify.
+        // Bytes that do not start with %PDF-. In production, CGImageSource
+        // would reject arbitrary bytes inside ImageProcessingService.validateImage;
+        // we mirror that by flipping shouldFailValidate on the mock so the
+        // single-pass image probe in DocumentBlobService.process throws and
+        // is re-thrown as ModelError.unsupportedContent.
+        ctx.imageProcessor.shouldFailValidate = true
         let arbitrary = Data([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07])
         await #expect(throws: ModelError.self) {
             _ = try await ctx.service.store(

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/ViewModels/Documents/DocumentPickerViewModelExtendedTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/ViewModels/Documents/DocumentPickerViewModelExtendedTests.swift
@@ -120,62 +120,6 @@ struct DocumentPickerViewModelExtendedTests {
     }
 
     @Test
-    func addFromDocumentPicker_mimeTypeFromPDFExtension() async throws {
-        let fixtures = makeFixtures()
-        let pdfData = Data("%PDF-1.4".utf8)
-        let url = try writeTempFile(name: "mime_pdf_\(UUID().uuidString).pdf", contents: pdfData)
-        defer { try? FileManager.default.removeItem(at: url) }
-
-        await fixtures.viewModel.addFromDocumentPicker([url])
-
-        if let call = fixtures.blobService.storeCalls.first {
-            #expect(call.mimeType == "application/pdf")
-        }
-    }
-
-    @Test
-    func addFromDocumentPicker_mimeTypeFromJPGExtension() async throws {
-        let fixtures = makeFixtures()
-        let jpegData = Data([0xFF, 0xD8, 0xFF, 0xE0]) + Data("jpeg body".utf8)
-        let url = try writeTempFile(name: "mime_jpeg_\(UUID().uuidString).jpg", contents: jpegData)
-        defer { try? FileManager.default.removeItem(at: url) }
-
-        await fixtures.viewModel.addFromDocumentPicker([url])
-
-        if let call = fixtures.blobService.storeCalls.first {
-            #expect(call.mimeType == "image/jpeg")
-        }
-    }
-
-    @Test
-    func addFromDocumentPicker_mimeTypeFromPNGExtension() async throws {
-        let fixtures = makeFixtures()
-        let pngData = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
-        let url = try writeTempFile(name: "mime_png_\(UUID().uuidString).png", contents: pngData)
-        defer { try? FileManager.default.removeItem(at: url) }
-
-        await fixtures.viewModel.addFromDocumentPicker([url])
-
-        if let call = fixtures.blobService.storeCalls.first {
-            #expect(call.mimeType == "image/png")
-        }
-    }
-
-    @Test
-    func addFromDocumentPicker_unknownExtension_fallsToOctetStream() async throws {
-        let fixtures = makeFixtures()
-        let data = Data("unknown body".utf8)
-        let url = try writeTempFile(name: "mime_unknown_\(UUID().uuidString).xyz", contents: data)
-        defer { try? FileManager.default.removeItem(at: url) }
-
-        await fixtures.viewModel.addFromDocumentPicker([url])
-
-        if let call = fixtures.blobService.storeCalls.first {
-            #expect(call.mimeType == "application/octet-stream")
-        }
-    }
-
-    @Test
     func addFromDocumentPicker_multipleFiles_addsSeveralDrafts() async throws {
         let fixtures = makeFixtures()
         let testId = UUID().uuidString

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/ViewModels/Documents/DocumentPickerViewModelTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/ViewModels/Documents/DocumentPickerViewModelTests.swift
@@ -306,6 +306,35 @@ struct DocumentPickerViewModelTests {
         #expect(fixtures.viewModel.drafts.first?.content.title == original)
     }
 
+    @Test
+    func setTitle_overMaxLength_truncatesToMax() async throws {
+        let fixtures = makeFixtures()
+        let image = makeTestImage()
+        await fixtures.viewModel.addFromCamera(image)
+
+        let draftId = try #require(fixtures.viewModel.drafts.first?.id)
+        let overLong = String(repeating: "z", count: DocumentReferenceRecord.titleMaxLength + 100)
+        fixtures.viewModel.setTitle(overLong, for: draftId)
+
+        // The assignment routes through DocumentReferenceRecord.title's computed
+        // setter, which normalizes via Self.normalizedTitle(_:) — the structural
+        // invariant means setTitle does not need an explicit normalization call.
+        #expect(fixtures.viewModel.drafts.first?.content.title.count == DocumentReferenceRecord.titleMaxLength)
+    }
+
+    @Test
+    func setTitle_exactlyMaxLength_keepsFullTitle() async throws {
+        let fixtures = makeFixtures()
+        let image = makeTestImage()
+        await fixtures.viewModel.addFromCamera(image)
+
+        let draftId = try #require(fixtures.viewModel.drafts.first?.id)
+        let maxTitle = String(repeating: "y", count: DocumentReferenceRecord.titleMaxLength)
+        fixtures.viewModel.setTitle(maxTitle, for: draftId)
+
+        #expect(fixtures.viewModel.drafts.first?.content.title == maxTitle)
+    }
+
     // MARK: - Sheet State Tests
 
     @Test

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/ViewModels/Documents/DocumentPickerViewModelTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/ViewModels/Documents/DocumentPickerViewModelTests.swift
@@ -196,7 +196,8 @@ struct DocumentPickerViewModelTests {
 
         let draft = try #require(fixtures.viewModel.drafts.first)
         #expect(draft.content.title.hasPrefix("Photo_"))
-        #expect(draft.content.title.hasSuffix(".jpg"))
+        // UTType.jpeg.preferredFilenameExtension is "jpeg", not "jpg".
+        #expect(draft.content.title.hasSuffix(".jpeg"))
     }
 
     @Test

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/ViewModels/Documents/DocumentPickerViewModelTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/ViewModels/Documents/DocumentPickerViewModelTests.swift
@@ -316,9 +316,7 @@ struct DocumentPickerViewModelTests {
         let overLong = String(repeating: "z", count: DocumentReferenceRecord.titleMaxLength + 100)
         fixtures.viewModel.setTitle(overLong, for: draftId)
 
-        // The assignment routes through DocumentReferenceRecord.title's computed
-        // setter, which normalizes via Self.normalizedTitle(_:) — the structural
-        // invariant means setTitle does not need an explicit normalization call.
+        // Regression guard: DocumentReferenceRecord.title must enforce length structurally.
         #expect(fixtures.viewModel.drafts.first?.content.title.count == DocumentReferenceRecord.titleMaxLength)
     }
 

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/ViewModels/Documents/DocumentPickerViewModelTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/ViewModels/Documents/DocumentPickerViewModelTests.swift
@@ -175,16 +175,14 @@ struct DocumentPickerViewModelTests {
     }
 
     @Test
-    func addFromCamera_callsStoreWithJPEG() async {
+    func addFromCamera_callsStore() async {
         let fixtures = makeFixtures()
         let image = makeTestImage()
 
         await fixtures.viewModel.addFromCamera(image)
 
         #expect(fixtures.blobService.storeCalls.count == 1)
-        let call = fixtures.blobService.storeCalls[0]
-        #expect(call.mimeType == "image/jpeg")
-        #expect(call.personId == fixtures.personId)
+        #expect(fixtures.blobService.storeCalls[0].personId == fixtures.personId)
     }
 
     @Test
@@ -203,7 +201,7 @@ struct DocumentPickerViewModelTests {
     @Test
     func addFromCamera_storeFailure_setsError() async {
         let fixtures = makeFixtures()
-        fixtures.blobService.storeError = ModelError.unsupportedMimeType(mimeType: "image/jpeg")
+        fixtures.blobService.storeError = ModelError.unsupportedContent
         let image = makeTestImage()
 
         await fixtures.viewModel.addFromCamera(image)

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -72,7 +72,6 @@ FILE_EXCEPTIONS = {
     "DemoSetupView.swift": 0.0,
     # ViewModels with static factory methods that use production dependencies
     "DocumentViewerViewModel.swift": 71.0,  # createDefaultDocumentService() uses real Core Data/services
-    "DocumentPickerViewModel.swift": 58.0,  # createDefaultDocumentService() + test seeding code; CI variance ~5%. Dropped during FHIR migration (#123) — restore to 68% in #127
     # Services with file system operations - CI/local variance in directory creation paths
     "DocumentFileStorageService.swift": 79.0,  # Local 80%, CI 89% - variance in default init tests
     # OPAQUE authentication - requires backend server for full integration testing


### PR DESCRIPTION
## Summary

Closes issue #149. Three related corrections to the attachment pipeline, delivered as six commits that can be reviewed commit-by-commit:

1. **Filenames reflect actual stored content**, not a hard-coded `.jpg`. Camera → `Photo_….jpeg`; photo library → `.png`/`.heic`/`.jpeg`/etc. matching the bytes CGImageSource detected; document picker preserves the user's filename verbatim.
2. **`DocumentBlobService.store()` is now content-driven** — no `mimeType` parameter. Detection via `%PDF-` magic-byte sniff and CGImageSource. Kills a sentinel string, a helper function, an extension-to-mime mapping, and four dead tests.
3. **`DocumentReferenceRecord.title` is structurally capped at 255 grapheme clusters**. `title` is now a computed property backed by `private _title`, with the setter routing through `normalizedTitle(_:)`. Any assignment anywhere in the module — including `record.title = rawString` — is automatically normalized. Type-enforced invariant, not caller discipline.

## User-visible behavior changes

- **Camera capture titles:** `Photo_….jpg` → `Photo_….jpeg`. Reason: `UTType.jpeg.preferredFilenameExtension` is the canonical `"jpeg"`, not `"jpg"`. Verified by running CGImageSource in an executed snippet.
- **Photo-library titles:** previously always `.jpg` regardless of bytes, now match actually-stored format.
- **Error message for unsupported content:** `"File type 'X' is not supported. Please use JPEG, PNG, or PDF."` → `"File type is not supported. Please use JPEG, PNG, HEIC, or PDF."` (no MIME to report when content is sniffed and rejected).
- **Unsupported file types:** `ModelError.unsupportedMimeType(mimeType:)` → `.unsupportedContent`. No users yet, so no migration concern.

## Architectural improvements

- New shared `String.appendingCanonicalExtension(forMimeType:fallback:)` extension replaces duplicated MIME-to-extension helpers in `DocumentViewerViewModel.sanitizedFileName` and the (now-deleted) `DocumentPickerViewModel.filename`. 100% covered.
- `DocumentPickerViewModel.storeAndAppend` + `storeAndAppendGenerated` collapsed into one method + a `TitleStrategy` enum (`.verbatim(String)` / `.derived(baseName: String)`).
- Removed stale 58% coverage exception on `DocumentPickerViewModel.swift` (actual: 85.26%).
- `DocumentBlobService.swift` coverage rose to **95.50%** after the content-driven refactor.
- `DocumentReferenceRecord.swift` coverage is at **98.00%** after the length cap + structural enforcement.

## Commits

Reviewable individually:

1. `d197d44` — fix: derive filenames from detected content format
2. `cfe616b` — refactor: make DocumentBlobService content-driven
3. `8dc7825` — feat: cap DocumentReferenceRecord.title at 255 chars
4. `870eb94` — refactor: enforce title length invariant structurally (day-1 correction: `_title` + computed property)
5. `d016007` — test: verify setTitle truncates via computed property setter (empirical verification of the structural claim with zero production-code change)
6. `c53d75c` — test: trim truncation-test comment to regression guard

## Scope deliberately deferred

- **#160** — camera capture still re-encodes to JPEG because `UIImagePickerController` delivers a pre-decoded `UIImage`. Fixing this properly needs a swap to `AVCapturePhotoOutput` (custom preview, shutter, focus/exposure controls). Out of scope for this PR; tracked as a separate issue and referenced in the camera-path comment in code.
- **Grapheme-vs-byte precision**: the 255 cap is measured in Swift `Character`s (extended grapheme clusters), which is a loose upper bound on UTF-8 byte count (~1.5KB worst case for pathological Unicode). Acceptable for the threat model (adversarial bloat of encrypted store / backup JSON / SwiftUI render). Documented in the `titleMaxLength` doc comment.

## Test plan

- [x] `./scripts/run-tests.sh` — **1549/1552** passing, 3 skipped, 0 failures (total rose by 11: +9 from `DocumentReferenceRecordTitleLengthTests`, +2 from `DocumentPickerViewModelTests` setTitle truncation tests)
- [x] `./scripts/check-coverage.sh` — **PASSED**. Overall 84.76% ≥ 83%. All files meet 85% per-file threshold (or their exceptions). Key files:
  - `DocumentReferenceRecord.swift`: 98.00%
  - `DocumentBlobService.swift`: 95.50%
  - `DocumentPickerViewModel.swift`: 85.26%
  - `DocumentViewerViewModel.swift`: 96.81%
  - `String+FilenameExtension.swift`: 100%
- [x] `pre-commit run` on all edited files across all six commits — all green (SwiftFormat, SwiftLint, no-XCTest, etc.)
- [x] Manual inspection: confirmed `DocumentPickerViewModel.setTitle(_:for:)` is unchanged post-structural-fix, yet `setTitle_overMaxLength_truncatesToMax` still passes — empirical proof that Swift's `_modify` accessor chain routes the mutation through the computed setter
- [ ] Reviewer: confirm the `.jpg` → `.jpeg` filename change is acceptable (single-user hobby app with no production users means no migration concern, but worth eyeballing)

## Closes

- Closes #149

## Summary by Sourcery

Make attachment handling content-driven, normalize document titles, and align filenames and errors with detected formats.

New Features:
- Enforce a 255-character grapheme-based maximum on DocumentReferenceRecord titles with automatic normalization at all ingestion points.
- Introduce a shared String helper to derive canonical filename extensions from MIME types for attachment titles and exported filenames.

Bug Fixes:
- Derive attachment filenames and thumbnails from the actual detected content format instead of hard-coded extensions or MIME hints.
- Update error handling to treat unsupported attachments as unsupported content rather than unsupported MIME types, with clearer user-facing copy.

Enhancements:
- Refactor DocumentBlobService to detect PDFs and images directly from bytes, simplifying the API by removing the mimeType parameter and relying on content sniffing.
- Simplify DocumentPickerViewModel title generation through a TitleStrategy abstraction and rely on detected MIME types when creating drafts.
- Adjust DocumentViewerViewModel filename sanitization to use the canonical extension helper and remove duplicated UTType logic.
- Strengthen tests and mocks around blob storage, title length enforcement, and filename extension behavior, increasing coverage and removing stale coverage exceptions.

Tests:
- Add comprehensive tests for DocumentReferenceRecord title length normalization across initializers and decoding paths.
- Add tests for the new String filename-extension helper and update blob service and picker/viewer tests to reflect content-driven detection and title truncation behavior.