### PR TITLE
feat: orphan blob cleanup — automatic + manual, per-person, race-safe

### DIFF
--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Crypto/FamilyMemberKeyService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Crypto/FamilyMemberKeyService.swift
@@ -2,7 +2,7 @@ import CryptoKit
 import Foundation
 
 /// Protocol for Family Member Key (FMK) operations
-protocol FamilyMemberKeyServiceProtocol {
+protocol FamilyMemberKeyServiceProtocol: Sendable {
     /// Generate a new random 256-bit Family Member Key
     /// - Returns: Fresh 256-bit SymmetricKey
     func generateFMK() -> SymmetricKey

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentBlobService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentBlobService.swift
@@ -90,13 +90,13 @@ final class DocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sendabl
             let hmac = Data(HMAC<SHA256>.authenticationCode(for: processed.data, using: fmk))
 
             let encryptedSize: Int
-            if fileStorage.exists(contentHMAC: hmac) {
+            if fileStorage.exists(contentHMAC: hmac, personId: personId) {
                 // Dedup: blob already on disk — skip re-encryption and re-write.
                 // Return 0 as placeholder since we don't know the encrypted size without reading the file.
                 encryptedSize = 0
             } else {
                 let encrypted = try encryptionService.encrypt(processed.data, using: fmk).combined
-                _ = try fileStorage.store(encryptedData: encrypted, contentHMAC: hmac)
+                _ = try fileStorage.store(encryptedData: encrypted, contentHMAC: hmac, personId: personId)
                 encryptedSize = encrypted.count
             }
             logger.exit("store", duration: ContinuousClock.now - start)
@@ -121,7 +121,7 @@ final class DocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sendabl
         logger.entry("retrieve")
         do {
             let fmk = try fmkService.retrieveFMK(familyMemberID: personId.uuidString, primaryKey: primaryKey)
-            let encrypted = try fileStorage.retrieve(contentHMAC: contentHMAC)
+            let encrypted = try fileStorage.retrieve(contentHMAC: contentHMAC, personId: personId)
             let plaintext: Data
             do {
                 let payload = try EncryptedPayload(combined: encrypted)
@@ -140,7 +140,8 @@ final class DocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sendabl
 
     func deleteIfUnreferenced(contentHMAC: Data, isReferencedElsewhere: Bool) async throws {
         guard !isReferencedElsewhere else { return }
-        try fileStorage.delete(contentHMAC: contentHMAC)
+        // Task 2: will receive personId from caller once DocumentBlobService is converted to an actor
+        try fileStorage.delete(contentHMAC: contentHMAC, personId: UUID())
     }
 
     // MARK: - Factory

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentBlobService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentBlobService.swift
@@ -26,7 +26,14 @@ protocol DocumentBlobServiceProtocol: Sendable {
 
     /// Delete a blob from disk if no DocumentReferenceRecord still references it.
     /// Callers determine `isReferencedElsewhere` by querying DocumentReferenceQueryService.
-    func deleteIfUnreferenced(contentHMAC: Data, isReferencedElsewhere: Bool) async throws
+    ///
+    /// - Parameters:
+    ///   - contentHMAC: The HMAC of the blob to potentially delete.
+    ///   - personId: The person whose subdirectory holds the blob. Required so the
+    ///     underlying file-storage service can locate the per-person `.enc` file.
+    ///   - isReferencedElsewhere: If `true`, the blob is preserved (another record still
+    ///     points at this HMAC).
+    func deleteIfUnreferenced(contentHMAC: Data, personId: UUID, isReferencedElsewhere: Bool) async throws
 }
 
 final class DocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sendable {
@@ -83,10 +90,14 @@ final class DocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sendabl
         primaryKey: SymmetricKey
     ) async throws -> StoredBlob {
         let start = ContinuousClock.now
+        // Emit entry *before* any fallible work so every error path has a matching
+        // `exitWithError`. Details that depend on downstream results (detected MIME,
+        // processed size) are logged later via a regular debug line.
+        logger.entry("store", "personId=\(personId), plaintextSize=\(plaintext.count)")
         do {
             let fmk = try fmkService.retrieveFMK(familyMemberID: personId.uuidString, primaryKey: primaryKey)
             let processed = try process(plaintext: plaintext)
-            logger.entry("store", "detectedMime=\(processed.detectedMimeType), plaintextSize=\(plaintext.count)")
+            logger.debug("store detectedMime=\(processed.detectedMimeType), processedSize=\(processed.data.count)")
             let hmac = Data(HMAC<SHA256>.authenticationCode(for: processed.data, using: fmk))
 
             let encryptedSize: Int
@@ -118,7 +129,7 @@ final class DocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sendabl
         primaryKey: SymmetricKey
     ) async throws -> Data {
         let start = ContinuousClock.now
-        logger.entry("retrieve")
+        logger.entry("retrieve", "personId=\(personId)")
         do {
             let fmk = try fmkService.retrieveFMK(familyMemberID: personId.uuidString, primaryKey: primaryKey)
             let encrypted = try fileStorage.retrieve(contentHMAC: contentHMAC, personId: personId)
@@ -138,10 +149,20 @@ final class DocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sendabl
         }
     }
 
-    func deleteIfUnreferenced(contentHMAC: Data, isReferencedElsewhere: Bool) async throws {
-        guard !isReferencedElsewhere else { return }
-        // Task 2: will receive personId from caller once DocumentBlobService is converted to an actor
-        try fileStorage.delete(contentHMAC: contentHMAC, personId: UUID())
+    func deleteIfUnreferenced(contentHMAC: Data, personId: UUID, isReferencedElsewhere: Bool) async throws {
+        let start = ContinuousClock.now
+        logger.entry("deleteIfUnreferenced", "personId=\(personId), referenced=\(isReferencedElsewhere)")
+        guard !isReferencedElsewhere else {
+            logger.exit("deleteIfUnreferenced", duration: ContinuousClock.now - start)
+            return
+        }
+        do {
+            try fileStorage.delete(contentHMAC: contentHMAC, personId: personId)
+            logger.exit("deleteIfUnreferenced", duration: ContinuousClock.now - start)
+        } catch {
+            logger.exitWithError("deleteIfUnreferenced", error: error, duration: ContinuousClock.now - start)
+            throw error
+        }
     }
 
     // MARK: - Factory

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentBlobService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentBlobService.swift
@@ -71,7 +71,8 @@ actor DocumentBlobService: DocumentBlobServiceProtocol {
 
     // MARK: - Types
 
-    struct StoredBlob: Equatable {
+    struct StoredBlob: Equatable { // Explicit Sendable to prevent silent regression if fields change — auto-inference
+        // is fragile under future edits.
         let contentHMAC: Data
         let encryptedSize: Int
         let thumbnailData: Data?
@@ -95,10 +96,10 @@ actor DocumentBlobService: DocumentBlobServiceProtocol {
 
     // MARK: - In-Flight State
 
-    /// HMACs of blobs currently being written to disk but not yet committed to
-    /// Core Data. The cleanup scanner consults this set and skips any HMAC still
-    /// in flight to avoid deleting a blob during the small window between the
-    /// on-disk write and the Core Data save.
+    /// HMACs that have been speculatively written to disk but not yet committed
+    /// to Core Data. Cleared on commit or rollback. Process-local: a crash mid-flight
+    /// is safe because the blob either already landed on disk (benign orphan the
+    /// next cleanup scan will remove) or never did.
     private var inFlightHMACs: Set<Data> = []
 
     init(
@@ -244,15 +245,23 @@ actor DocumentBlobService: DocumentBlobServiceProtocol {
     // MARK: - In-Flight Tracking
 
     func markInFlight(contentHMAC: Data) {
-        inFlightHMACs.insert(contentHMAC)
-        logger.debug("markInFlight count=\(inFlightHMACs.count)")
+        let (inserted, _) = inFlightHMACs.insert(contentHMAC)
+        if !inserted {
+            logger.debug("markInFlight: HMAC already in flight, count=\(inFlightHMACs.count)")
+        } else {
+            logger.debug("markInFlight: added, count=\(inFlightHMACs.count)")
+        }
     }
 
     func clearInFlight(contentHMAC: Data) {
-        inFlightHMACs.remove(contentHMAC)
-        logger.debug("clearInFlight count=\(inFlightHMACs.count)")
+        if inFlightHMACs.remove(contentHMAC) == nil {
+            logger.debug("clearInFlight: HMAC not in flight, count=\(inFlightHMACs.count)")
+        } else {
+            logger.debug("clearInFlight: removed, count=\(inFlightHMACs.count)")
+        }
     }
 
+    /// No debug log on isInFlight: called per-blob in cleanup scans, would flood logs.
     func isInFlight(contentHMAC: Data) -> Bool {
         inFlightHMACs.contains(contentHMAC)
     }

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentBlobService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentBlobService.swift
@@ -11,6 +11,13 @@ protocol DocumentBlobServiceProtocol: Sendable {
     /// Encrypt, store, and return storage metadata for a plaintext blob. The content type
     /// is detected from the bytes themselves (PDF via `%PDF-` magic bytes, images via
     /// CGImageSource); callers do not pass a MIME hint.
+    ///
+    /// Stored blobs are automatically marked in-flight as part of the same actor-isolated
+    /// body that writes the blob to disk — no interleaving window exists where the orphan
+    /// cleanup scanner could observe the on-disk blob without also observing the in-flight
+    /// bit. Callers must `clearInFlight` after the referencing record is saved, or
+    /// `clearInFlight` (typically via `removeDraft`) when the draft is discarded, otherwise
+    /// the cleanup scanner will perpetually skip the blob for the process lifetime.
     func store(
         plaintext: Data,
         personId: UUID,
@@ -54,6 +61,12 @@ protocol DocumentBlobServiceProtocol: Sendable {
     /// Mark a content HMAC as "currently being written" so the cleanup scanner
     /// does not delete it as an orphan during the gap between blob storage
     /// and Core Data commit.
+    ///
+    /// The common `store`-then-save flow does NOT need to call this: `store` marks
+    /// its output HMAC in-flight as part of the same actor-serialized body that
+    /// writes the blob. This entry point is retained for external callers (mocks,
+    /// import flows, future features) that want to mark an HMAC without first
+    /// calling `store`.
     func markInFlight(contentHMAC: Data) async
 
     /// Clear a previously marked in-flight HMAC (on commit or rollback).
@@ -149,6 +162,13 @@ actor DocumentBlobService: DocumentBlobServiceProtocol {
                 _ = try fileStorage.store(encryptedData: encrypted, contentHMAC: hmac, personId: personId)
                 encryptedSize = encrypted.count
             }
+            // Atomically mark the HMAC in-flight inside this same actor-isolated method
+            // body, before returning. Because the insert and the file-storage write are
+            // both serialized on this actor, no cleanup scanner can observe the on-disk
+            // blob without also observing the in-flight bit — closing the race where a
+            // scan would otherwise delete a just-stored blob before the caller's record
+            // save could reference it.
+            inFlightHMACs.insert(hmac)
             logger.exit("store", duration: ContinuousClock.now - start)
             return StoredBlob(
                 contentHMAC: hmac,

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentBlobService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentBlobService.swift
@@ -71,13 +71,16 @@ actor DocumentBlobService: DocumentBlobServiceProtocol {
 
     // MARK: - Types
 
-    struct StoredBlob: Equatable { // Explicit Sendable to prevent silent regression if fields change — auto-inference
-        // is fragile under future edits.
+    // swiftformat:disable redundantSendable
+    /// Explicit Sendable to prevent silent regression if fields change — auto-inference is fragile under future edits.
+    struct StoredBlob: Equatable, Sendable {
         let contentHMAC: Data
         let encryptedSize: Int
         let thumbnailData: Data?
         let detectedMimeType: String
     }
+
+    // swiftformat:enable redundantSendable
 
     /// Result of `process()`: the data to store, optional thumbnail, and detected MIME.
     private struct ProcessedBlob {

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentBlobService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentBlobService.swift
@@ -34,9 +34,36 @@ protocol DocumentBlobServiceProtocol: Sendable {
     ///   - isReferencedElsewhere: If `true`, the blob is preserved (another record still
     ///     points at this HMAC).
     func deleteIfUnreferenced(contentHMAC: Data, personId: UUID, isReferencedElsewhere: Bool) async throws
+
+    // MARK: - Cleanup Support
+
+    /// List every blob HMAC currently on disk for a person.
+    /// Used by the orphan cleanup scanner to compare against the set of
+    /// referenced HMACs from the database.
+    func listBlobs(personId: UUID) async throws -> Set<Data>
+
+    /// Return the on-disk size of a specific blob in bytes.
+    func blobSize(contentHMAC: Data, personId: UUID) async throws -> UInt64
+
+    /// Delete a blob unconditionally (no reference check). Used by the cleanup
+    /// scanner, which has already determined the blob is an orphan.
+    func deleteDirect(contentHMAC: Data, personId: UUID) async throws
+
+    // MARK: - In-Flight Tracking
+
+    /// Mark a content HMAC as "currently being written" so the cleanup scanner
+    /// does not delete it as an orphan during the gap between blob storage
+    /// and Core Data commit.
+    func markInFlight(contentHMAC: Data) async
+
+    /// Clear a previously marked in-flight HMAC (on commit or rollback).
+    func clearInFlight(contentHMAC: Data) async
+
+    /// Check whether an HMAC is currently marked as in-flight.
+    func isInFlight(contentHMAC: Data) async -> Bool
 }
 
-final class DocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sendable {
+actor DocumentBlobService: DocumentBlobServiceProtocol {
     // MARK: - Constants
 
     static let maxFileSizeBytes = 10 * 1_024 * 1_024
@@ -65,6 +92,14 @@ final class DocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sendabl
     private let encryptionService: EncryptionServiceProtocol
     private let fmkService: FamilyMemberKeyServiceProtocol
     private let logger: TracingCategoryLogger
+
+    // MARK: - In-Flight State
+
+    /// HMACs of blobs currently being written to disk but not yet committed to
+    /// Core Data. The cleanup scanner consults this set and skips any HMAC still
+    /// in flight to avoid deleting a blob during the small window between the
+    /// on-disk write and the Core Data save.
+    private var inFlightHMACs: Set<Data> = []
 
     init(
         fileStorage: DocumentFileStorageServiceProtocol,
@@ -163,6 +198,63 @@ final class DocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sendabl
             logger.exitWithError("deleteIfUnreferenced", error: error, duration: ContinuousClock.now - start)
             throw error
         }
+    }
+
+    // MARK: - Cleanup Support
+
+    func listBlobs(personId: UUID) async throws -> Set<Data> {
+        let start = ContinuousClock.now
+        logger.entry("listBlobs", "personId=\(personId)")
+        do {
+            let blobs = try fileStorage.listBlobs(personId: personId)
+            logger.debug("listBlobs returned \(blobs.count) blobs")
+            logger.exit("listBlobs", duration: ContinuousClock.now - start)
+            return blobs
+        } catch {
+            logger.exitWithError("listBlobs", error: error, duration: ContinuousClock.now - start)
+            throw error
+        }
+    }
+
+    func blobSize(contentHMAC: Data, personId: UUID) async throws -> UInt64 {
+        let start = ContinuousClock.now
+        logger.entry("blobSize", "personId=\(personId)")
+        do {
+            let size = try fileStorage.blobSize(contentHMAC: contentHMAC, personId: personId)
+            logger.exit("blobSize", duration: ContinuousClock.now - start)
+            return size
+        } catch {
+            logger.exitWithError("blobSize", error: error, duration: ContinuousClock.now - start)
+            throw error
+        }
+    }
+
+    func deleteDirect(contentHMAC: Data, personId: UUID) async throws {
+        let start = ContinuousClock.now
+        logger.entry("deleteDirect", "personId=\(personId)")
+        do {
+            try fileStorage.delete(contentHMAC: contentHMAC, personId: personId)
+            logger.exit("deleteDirect", duration: ContinuousClock.now - start)
+        } catch {
+            logger.exitWithError("deleteDirect", error: error, duration: ContinuousClock.now - start)
+            throw error
+        }
+    }
+
+    // MARK: - In-Flight Tracking
+
+    func markInFlight(contentHMAC: Data) {
+        inFlightHMACs.insert(contentHMAC)
+        logger.debug("markInFlight count=\(inFlightHMACs.count)")
+    }
+
+    func clearInFlight(contentHMAC: Data) {
+        inFlightHMACs.remove(contentHMAC)
+        logger.debug("clearInFlight count=\(inFlightHMACs.count)")
+    }
+
+    func isInFlight(contentHMAC: Data) -> Bool {
+        inFlightHMACs.contains(contentHMAC)
     }
 
     // MARK: - Factory

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentFileStorageService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentFileStorageService.swift
@@ -221,17 +221,20 @@ final class DocumentFileStorageService: DocumentFileStorageServiceProtocol, @unc
             guard fileManager.fileExists(atPath: fileURL.path) else {
                 throw ModelError.documentNotFound()
             }
-            let size: UInt64
+            let attrs: [FileAttributeKey: Any]
             do {
-                let attrs = try fileManager.attributesOfItem(atPath: fileURL.path)
-                guard let resolvedSize = attrs[.size] as? UInt64 else {
-                    throw ModelError.documentStorageFailed(
-                        reason: "Unexpected file size attribute type for \(fileURL.lastPathComponent)"
-                    )
-                }
-                size = resolvedSize
+                attrs = try fileManager.attributesOfItem(atPath: fileURL.path)
             } catch {
                 throw ModelError.documentStorageFailed(reason: error.localizedDescription)
+            }
+            // Guard lives outside the FileManager do/catch so its crafted reason string
+            // reaches the outer exitWithError tracing intact — an inner catch would
+            // rewrap this typed error via error.localizedDescription and drop the detail.
+            guard let size = attrs[.size] as? UInt64 else {
+                let actualType = attrs[.size].map { "\(type(of: $0))" } ?? "nil"
+                throw ModelError.documentStorageFailed(
+                    reason: "Unexpected file size attribute type '\(actualType)' for \(fileURL.lastPathComponent)"
+                )
             }
             logger.exit("blobSize", duration: ContinuousClock.now - start)
             return size

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentFileStorageService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentFileStorageService.swift
@@ -7,38 +7,63 @@ import Foundation
 ///
 /// Per ADR-0004: Document blobs are stored separately from medical record metadata to enable
 /// efficient sync (editing a note field doesn't re-upload attached photos).
+///
+/// Blobs are stored under `Attachments/{personId}/{hmac}.enc` to enable per-person orphan cleanup.
 protocol DocumentFileStorageServiceProtocol: Sendable {
     /// Store encrypted data and return the storage URL
     ///
     /// - Parameters:
     ///   - encryptedData: The encrypted document content
     ///   - contentHMAC: HMAC-SHA256 of the plaintext content (keyed with FMK)
+    ///   - personId: The person whose subdirectory should hold the blob
     /// - Returns: URL where the data was stored
     /// - Throws: ModelError.documentStorageFailed if storage fails
-    func store(encryptedData: Data, contentHMAC: Data) throws -> URL
+    func store(encryptedData: Data, contentHMAC: Data, personId: UUID) throws -> URL
 
     /// Retrieve encrypted content by its HMAC
     ///
-    /// - Parameter contentHMAC: The content HMAC used as filename
+    /// - Parameters:
+    ///   - contentHMAC: The content HMAC used as filename
+    ///   - personId: The person whose subdirectory contains the blob
     /// - Returns: The encrypted document data
     /// - Throws: ModelError.documentNotFound if file doesn't exist,
     ///           ModelError.documentContentCorrupted if read fails
-    func retrieve(contentHMAC: Data) throws -> Data
+    func retrieve(contentHMAC: Data, personId: UUID) throws -> Data
 
     /// Delete content by its HMAC
     ///
-    /// - Parameter contentHMAC: The content HMAC of the file to delete
+    /// - Parameters:
+    ///   - contentHMAC: The content HMAC of the file to delete
+    ///   - personId: The person whose subdirectory contains the blob
     /// - Throws: ModelError.documentStorageFailed if deletion fails
-    func delete(contentHMAC: Data) throws
+    func delete(contentHMAC: Data, personId: UUID) throws
 
     /// Check if content exists for the given HMAC
     ///
-    /// - Parameter contentHMAC: The content HMAC to check
+    /// - Parameters:
+    ///   - contentHMAC: The content HMAC to check
+    ///   - personId: The person whose subdirectory to check
     /// - Returns: true if file exists, false otherwise
-    func exists(contentHMAC: Data) -> Bool
+    func exists(contentHMAC: Data, personId: UUID) -> Bool
+
+    /// List all blob HMACs stored for a person
+    ///
+    /// - Parameter personId: The person whose subdirectory to enumerate
+    /// - Returns: Set of HMAC Data values for every `.enc` file found
+    /// - Throws: ModelError.documentStorageFailed if directory enumeration fails
+    func listBlobs(personId: UUID) throws -> Set<Data>
+
+    /// Return the on-disk size of a stored blob in bytes
+    ///
+    /// - Parameters:
+    ///   - contentHMAC: The content HMAC of the file
+    ///   - personId: The person whose subdirectory contains the blob
+    /// - Returns: File size in bytes
+    /// - Throws: ModelError.documentStorageFailed if attributes cannot be read
+    func blobSize(contentHMAC: Data, personId: UUID) throws -> UInt64
 }
 
-/// Default implementation storing documents in Application Support/Attachments/
+/// Default implementation storing documents in Application Support/Attachments/{personId}/
 final class DocumentFileStorageService: DocumentFileStorageServiceProtocol, @unchecked Sendable {
     // MARK: - Properties
 
@@ -64,8 +89,9 @@ final class DocumentFileStorageService: DocumentFileStorageServiceProtocol, @unc
 
     // MARK: - DocumentFileStorageServiceProtocol
 
-    func store(encryptedData: Data, contentHMAC: Data) throws -> URL {
-        let fileURL = fileURL(for: contentHMAC)
+    func store(encryptedData: Data, contentHMAC: Data, personId: UUID) throws -> URL {
+        let dirURL = try ensurePersonDirectory(for: personId)
+        let fileURL = blobURL(for: contentHMAC, in: dirURL)
 
         // If file already exists (deduplication), skip write
         if fileManager.fileExists(atPath: fileURL.path) {
@@ -82,8 +108,8 @@ final class DocumentFileStorageService: DocumentFileStorageServiceProtocol, @unc
         }
     }
 
-    func retrieve(contentHMAC: Data) throws -> Data {
-        let fileURL = fileURL(for: contentHMAC)
+    func retrieve(contentHMAC: Data, personId: UUID) throws -> Data {
+        let fileURL = fileURL(for: contentHMAC, personId: personId)
 
         guard fileManager.fileExists(atPath: fileURL.path) else {
             logger.error("Document file not found")
@@ -98,8 +124,8 @@ final class DocumentFileStorageService: DocumentFileStorageServiceProtocol, @unc
         }
     }
 
-    func delete(contentHMAC: Data) throws {
-        let fileURL = fileURL(for: contentHMAC)
+    func delete(contentHMAC: Data, personId: UUID) throws {
+        let fileURL = fileURL(for: contentHMAC, personId: personId)
 
         // If file doesn't exist, consider it already deleted (idempotent)
         guard fileManager.fileExists(atPath: fileURL.path) else {
@@ -115,23 +141,99 @@ final class DocumentFileStorageService: DocumentFileStorageServiceProtocol, @unc
         }
     }
 
-    func exists(contentHMAC: Data) -> Bool {
-        let fileURL = fileURL(for: contentHMAC)
+    func exists(contentHMAC: Data, personId: UUID) -> Bool {
+        let fileURL = fileURL(for: contentHMAC, personId: personId)
         return fileManager.fileExists(atPath: fileURL.path)
+    }
+
+    func listBlobs(personId: UUID) throws -> Set<Data> {
+        let dirURL = personDirectory(for: personId)
+        guard fileManager.fileExists(atPath: dirURL.path) else {
+            return [] // no directory yet = no blobs
+        }
+        do {
+            let files = try fileManager.contentsOfDirectory(
+                at: dirURL,
+                includingPropertiesForKeys: nil,
+                options: .skipsHiddenFiles
+            )
+            var hmacs = Set<Data>()
+            for file in files where file.pathExtension == "enc" {
+                if let hmac = hmacFromFilename(file.deletingPathExtension().lastPathComponent) {
+                    hmacs.insert(hmac)
+                }
+            }
+            return hmacs
+        } catch {
+            logger.logError(error, context: "DocumentFileStorageService.listBlobs")
+            throw ModelError.documentStorageFailed(reason: error.localizedDescription)
+        }
+    }
+
+    func blobSize(contentHMAC: Data, personId: UUID) throws -> UInt64 {
+        let fileURL = fileURL(for: contentHMAC, personId: personId)
+        do {
+            let attrs = try fileManager.attributesOfItem(atPath: fileURL.path)
+            return attrs[.size] as? UInt64 ?? 0
+        } catch {
+            logger.logError(error, context: "DocumentFileStorageService.blobSize")
+            throw ModelError.documentStorageFailed(reason: error.localizedDescription)
+        }
     }
 
     // MARK: - Private Helpers
 
-    /// Generate file URL from content HMAC
+    /// Return the per-person subdirectory URL (may not exist yet)
+    private func personDirectory(for personId: UUID) -> URL {
+        attachmentsDirectory.appendingPathComponent(personId.uuidString, isDirectory: true)
+    }
+
+    /// Generate a blob file URL given its HMAC and parent directory
     ///
     /// Files are named as `<hmac-hex>.enc` where the HMAC is the hex-encoded
     /// HMAC-SHA256 of the plaintext content.
-    private func fileURL(for contentHMAC: Data) -> URL {
+    private func blobURL(for contentHMAC: Data, in directory: URL) -> URL {
         let hexName = contentHMAC.map { String(format: "%02x", $0) }.joined()
-        return attachmentsDirectory.appendingPathComponent("\(hexName).enc")
+        return directory.appendingPathComponent("\(hexName).enc")
     }
 
-    /// Create the attachments directory if it doesn't exist
+    /// Generate file URL from content HMAC and person ID
+    private func fileURL(for contentHMAC: Data, personId: UUID) -> URL {
+        blobURL(for: contentHMAC, in: personDirectory(for: personId))
+    }
+
+    /// Create the per-person subdirectory if it doesn't exist, and return its URL
+    private func ensurePersonDirectory(for personId: UUID) throws -> URL {
+        let dirURL = personDirectory(for: personId)
+        if !fileManager.fileExists(atPath: dirURL.path) {
+            do {
+                try fileManager.createDirectory(
+                    at: dirURL,
+                    withIntermediateDirectories: true,
+                    attributes: [.protectionKey: FileProtectionType.complete]
+                )
+            } catch {
+                throw ModelError.documentStorageFailed(reason: error.localizedDescription)
+            }
+        }
+        return dirURL
+    }
+
+    /// Decode a hex string back to Data; returns nil on malformed input
+    private func hmacFromFilename(_ hex: String) -> Data? {
+        guard hex.count.isMultiple(of: 2) else { return nil }
+        var data = Data(capacity: hex.count / 2)
+        var index = hex.startIndex
+        while index < hex.endIndex {
+            let nextIndex = hex.index(index, offsetBy: 2)
+            guard let byte = UInt8(hex[index ..< nextIndex], radix: 16) else { return nil }
+            data.append(byte)
+            index = nextIndex
+        }
+        return data
+    }
+
+    /// Create the top-level attachments directory if it doesn't exist
     private static func createAttachmentsDirectory(fileManager: FileManager) throws -> URL {
         guard
             let appSupportURL = fileManager.urls(

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentFileStorageService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentFileStorageService.swift
@@ -224,7 +224,12 @@ final class DocumentFileStorageService: DocumentFileStorageServiceProtocol, @unc
             let size: UInt64
             do {
                 let attrs = try fileManager.attributesOfItem(atPath: fileURL.path)
-                size = attrs[.size] as? UInt64 ?? 0
+                guard let resolvedSize = attrs[.size] as? UInt64 else {
+                    throw ModelError.documentStorageFailed(
+                        reason: "Unexpected file size attribute type for \(fileURL.lastPathComponent)"
+                    )
+                }
+                size = resolvedSize
             } catch {
                 throw ModelError.documentStorageFailed(reason: error.localizedDescription)
             }

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentFileStorageService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentFileStorageService.swift
@@ -69,7 +69,7 @@ final class DocumentFileStorageService: DocumentFileStorageServiceProtocol, @unc
 
     private let fileManager: FileManager
     private let attachmentsDirectory: URL
-    private let logger: CategoryLoggerProtocol
+    private let logger: TracingCategoryLogger
 
     // MARK: - Initialization
 
@@ -77,107 +77,167 @@ final class DocumentFileStorageService: DocumentFileStorageServiceProtocol, @unc
     init(logger: CategoryLoggerProtocol? = nil) throws {
         self.fileManager = FileManager.default
         self.attachmentsDirectory = try Self.createAttachmentsDirectory(fileManager: fileManager)
-        self.logger = logger ?? LoggingService.shared.logger(category: .storage)
+        self.logger = TracingCategoryLogger(
+            wrapping: logger ?? LoggingService.shared.logger(category: .storage)
+        )
     }
 
     /// Initialize with custom directory (for testing)
     init(attachmentsDirectory: URL, fileManager: FileManager = .default, logger: CategoryLoggerProtocol? = nil) {
         self.fileManager = fileManager
         self.attachmentsDirectory = attachmentsDirectory
-        self.logger = logger ?? LoggingService.shared.logger(category: .storage)
+        self.logger = TracingCategoryLogger(
+            wrapping: logger ?? LoggingService.shared.logger(category: .storage)
+        )
     }
 
     // MARK: - DocumentFileStorageServiceProtocol
 
     func store(encryptedData: Data, contentHMAC: Data, personId: UUID) throws -> URL {
-        let dirURL = try ensurePersonDirectory(for: personId)
-        let fileURL = blobURL(for: contentHMAC, in: dirURL)
-
-        // If file already exists (deduplication), skip write
-        if fileManager.fileExists(atPath: fileURL.path) {
-            return fileURL
-        }
-
+        let start = ContinuousClock.now
+        logger.entry("store", "personId=\(personId), size=\(encryptedData.count)")
         do {
-            try encryptedData.write(to: fileURL, options: [.atomic, .completeFileProtection])
-            logger.debug("Stored document: \(encryptedData.count) bytes")
+            let dirURL = try ensurePersonDirectory(for: personId)
+            let fileURL = blobURL(for: contentHMAC, in: dirURL)
+
+            // If file already exists (deduplication), skip write
+            if fileManager.fileExists(atPath: fileURL.path) {
+                logger.exit("store", duration: ContinuousClock.now - start)
+                return fileURL
+            }
+
+            do {
+                try encryptedData.write(to: fileURL, options: [.atomic, .completeFileProtection])
+            } catch {
+                logger.logError(error, context: "DocumentFileStorageService.store")
+                throw ModelError.documentStorageFailed(reason: error.localizedDescription)
+            }
+            logger.exit("store", duration: ContinuousClock.now - start)
             return fileURL
         } catch {
-            logger.logError(error, context: "DocumentFileStorageService.store")
-            throw ModelError.documentStorageFailed(reason: error.localizedDescription)
+            logger.exitWithError("store", error: error, duration: ContinuousClock.now - start)
+            throw error
         }
     }
 
     func retrieve(contentHMAC: Data, personId: UUID) throws -> Data {
-        let fileURL = fileURL(for: contentHMAC, personId: personId)
-
-        guard fileManager.fileExists(atPath: fileURL.path) else {
-            logger.error("Document file not found")
-            throw ModelError.documentNotFound()
-        }
-
+        let start = ContinuousClock.now
+        logger.entry("retrieve", "personId=\(personId)")
         do {
-            return try Data(contentsOf: fileURL)
+            let fileURL = fileURL(for: contentHMAC, personId: personId)
+
+            guard fileManager.fileExists(atPath: fileURL.path) else {
+                throw ModelError.documentNotFound()
+            }
+
+            let data: Data
+            do {
+                data = try Data(contentsOf: fileURL)
+            } catch {
+                logger.logError(error, context: "DocumentFileStorageService.retrieve")
+                throw ModelError.documentContentCorrupted
+            }
+            logger.exit("retrieve", duration: ContinuousClock.now - start)
+            return data
         } catch {
-            logger.logError(error, context: "DocumentFileStorageService.retrieve")
-            throw ModelError.documentContentCorrupted
+            logger.exitWithError("retrieve", error: error, duration: ContinuousClock.now - start)
+            throw error
         }
     }
 
     func delete(contentHMAC: Data, personId: UUID) throws {
-        let fileURL = fileURL(for: contentHMAC, personId: personId)
-
-        // If file doesn't exist, consider it already deleted (idempotent)
-        guard fileManager.fileExists(atPath: fileURL.path) else {
-            return
-        }
-
+        let start = ContinuousClock.now
+        logger.entry("delete", "personId=\(personId)")
         do {
-            try fileManager.removeItem(at: fileURL)
-            logger.debug("Deleted document file")
+            let fileURL = fileURL(for: contentHMAC, personId: personId)
+
+            // If file doesn't exist, consider it already deleted (idempotent)
+            guard fileManager.fileExists(atPath: fileURL.path) else {
+                logger.exit("delete", duration: ContinuousClock.now - start)
+                return
+            }
+
+            do {
+                try fileManager.removeItem(at: fileURL)
+            } catch {
+                logger.logError(error, context: "DocumentFileStorageService.delete")
+                throw ModelError.documentStorageFailed(reason: error.localizedDescription)
+            }
+            logger.exit("delete", duration: ContinuousClock.now - start)
         } catch {
-            logger.logError(error, context: "DocumentFileStorageService.delete")
-            throw ModelError.documentStorageFailed(reason: error.localizedDescription)
+            logger.exitWithError("delete", error: error, duration: ContinuousClock.now - start)
+            throw error
         }
     }
 
     func exists(contentHMAC: Data, personId: UUID) -> Bool {
+        let start = ContinuousClock.now
+        logger.entry("exists", "personId=\(personId)")
         let fileURL = fileURL(for: contentHMAC, personId: personId)
-        return fileManager.fileExists(atPath: fileURL.path)
+        let present = fileManager.fileExists(atPath: fileURL.path)
+        logger.exit("exists", duration: ContinuousClock.now - start)
+        return present
     }
 
     func listBlobs(personId: UUID) throws -> Set<Data> {
-        let dirURL = personDirectory(for: personId)
-        guard fileManager.fileExists(atPath: dirURL.path) else {
-            return [] // no directory yet = no blobs
-        }
+        let start = ContinuousClock.now
+        logger.entry("listBlobs", "personId=\(personId)")
         do {
-            let files = try fileManager.contentsOfDirectory(
-                at: dirURL,
-                includingPropertiesForKeys: nil,
-                options: .skipsHiddenFiles
-            )
+            let dirURL = personDirectory(for: personId)
+            guard fileManager.fileExists(atPath: dirURL.path) else {
+                logger.exit("listBlobs", duration: ContinuousClock.now - start)
+                return [] // no directory yet = no blobs
+            }
+            let files: [URL]
+            do {
+                files = try fileManager.contentsOfDirectory(
+                    at: dirURL,
+                    includingPropertiesForKeys: nil,
+                    options: .skipsHiddenFiles
+                )
+            } catch {
+                logger.logError(error, context: "DocumentFileStorageService.listBlobs")
+                throw ModelError.documentStorageFailed(reason: error.localizedDescription)
+            }
             var hmacs = Set<Data>()
             for file in files where file.pathExtension == "enc" {
                 if let hmac = hmacFromFilename(file.deletingPathExtension().lastPathComponent) {
                     hmacs.insert(hmac)
                 }
             }
+            logger.debug("listBlobs returned \(hmacs.count) blobs")
+            logger.exit("listBlobs", duration: ContinuousClock.now - start)
             return hmacs
         } catch {
-            logger.logError(error, context: "DocumentFileStorageService.listBlobs")
-            throw ModelError.documentStorageFailed(reason: error.localizedDescription)
+            logger.exitWithError("listBlobs", error: error, duration: ContinuousClock.now - start)
+            throw error
         }
     }
 
     func blobSize(contentHMAC: Data, personId: UUID) throws -> UInt64 {
-        let fileURL = fileURL(for: contentHMAC, personId: personId)
+        let start = ContinuousClock.now
+        logger.entry("blobSize", "personId=\(personId)")
         do {
-            let attrs = try fileManager.attributesOfItem(atPath: fileURL.path)
-            return attrs[.size] as? UInt64 ?? 0
+            let fileURL = fileURL(for: contentHMAC, personId: personId)
+            // Distinguish "file missing" (a race with concurrent deletion — expected
+            // during cleanup scans) from "attributes unreadable" (permissions/IO error).
+            // The cleanup scanner can swallow `documentNotFound` safely.
+            guard fileManager.fileExists(atPath: fileURL.path) else {
+                throw ModelError.documentNotFound()
+            }
+            let size: UInt64
+            do {
+                let attrs = try fileManager.attributesOfItem(atPath: fileURL.path)
+                size = attrs[.size] as? UInt64 ?? 0
+            } catch {
+                logger.logError(error, context: "DocumentFileStorageService.blobSize")
+                throw ModelError.documentStorageFailed(reason: error.localizedDescription)
+            }
+            logger.exit("blobSize", duration: ContinuousClock.now - start)
+            return size
         } catch {
-            logger.logError(error, context: "DocumentFileStorageService.blobSize")
-            throw ModelError.documentStorageFailed(reason: error.localizedDescription)
+            logger.exitWithError("blobSize", error: error, duration: ContinuousClock.now - start)
+            throw error
         }
     }
 
@@ -202,26 +262,33 @@ final class DocumentFileStorageService: DocumentFileStorageServiceProtocol, @unc
         blobURL(for: contentHMAC, in: personDirectory(for: personId))
     }
 
-    /// Create the per-person subdirectory if it doesn't exist, and return its URL
+    /// Create the per-person subdirectory if it doesn't exist, and return its URL.
+    ///
+    /// `createDirectory(withIntermediateDirectories: true)` is idempotent — it succeeds
+    /// whether or not the directory exists, so no pre-`fileExists` guard is needed.
+    /// `.protectionKey` is only applied on actual creation; re-calling on an existing
+    /// directory is a no-op for attributes.
     private func ensurePersonDirectory(for personId: UUID) throws -> URL {
         let dirURL = personDirectory(for: personId)
-        if !fileManager.fileExists(atPath: dirURL.path) {
-            do {
-                try fileManager.createDirectory(
-                    at: dirURL,
-                    withIntermediateDirectories: true,
-                    attributes: [.protectionKey: FileProtectionType.complete]
-                )
-            } catch {
-                throw ModelError.documentStorageFailed(reason: error.localizedDescription)
-            }
+        do {
+            try fileManager.createDirectory(
+                at: dirURL,
+                withIntermediateDirectories: true,
+                attributes: [.protectionKey: FileProtectionType.complete]
+            )
+        } catch {
+            throw ModelError.documentStorageFailed(reason: error.localizedDescription)
         }
         return dirURL
     }
 
-    /// Decode a hex string back to Data; returns nil on malformed input
+    /// Decode a hex string back to Data; returns nil on malformed input.
+    ///
+    /// An empty string produces `nil` so a stray `.enc` file (or any zero-length
+    /// filename stem) is rejected rather than inserting an empty-HMAC entry into
+    /// the caller's Set.
     private func hmacFromFilename(_ hex: String) -> Data? {
-        guard hex.count.isMultiple(of: 2) else { return nil }
+        guard !hex.isEmpty, hex.count.isMultiple(of: 2) else { return nil }
         var data = Data(capacity: hex.count / 2)
         var index = hex.startIndex
         while index < hex.endIndex {

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentFileStorageService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentFileStorageService.swift
@@ -109,7 +109,6 @@ final class DocumentFileStorageService: DocumentFileStorageServiceProtocol, @unc
             do {
                 try encryptedData.write(to: fileURL, options: [.atomic, .completeFileProtection])
             } catch {
-                logger.logError(error, context: "DocumentFileStorageService.store")
                 throw ModelError.documentStorageFailed(reason: error.localizedDescription)
             }
             logger.exit("store", duration: ContinuousClock.now - start)
@@ -134,7 +133,6 @@ final class DocumentFileStorageService: DocumentFileStorageServiceProtocol, @unc
             do {
                 data = try Data(contentsOf: fileURL)
             } catch {
-                logger.logError(error, context: "DocumentFileStorageService.retrieve")
                 throw ModelError.documentContentCorrupted
             }
             logger.exit("retrieve", duration: ContinuousClock.now - start)
@@ -160,7 +158,6 @@ final class DocumentFileStorageService: DocumentFileStorageServiceProtocol, @unc
             do {
                 try fileManager.removeItem(at: fileURL)
             } catch {
-                logger.logError(error, context: "DocumentFileStorageService.delete")
                 throw ModelError.documentStorageFailed(reason: error.localizedDescription)
             }
             logger.exit("delete", duration: ContinuousClock.now - start)
@@ -196,7 +193,6 @@ final class DocumentFileStorageService: DocumentFileStorageServiceProtocol, @unc
                     options: .skipsHiddenFiles
                 )
             } catch {
-                logger.logError(error, context: "DocumentFileStorageService.listBlobs")
                 throw ModelError.documentStorageFailed(reason: error.localizedDescription)
             }
             var hmacs = Set<Data>()
@@ -230,7 +226,6 @@ final class DocumentFileStorageService: DocumentFileStorageServiceProtocol, @unc
                 let attrs = try fileManager.attributesOfItem(atPath: fileURL.path)
                 size = attrs[.size] as? UInt64 ?? 0
             } catch {
-                logger.logError(error, context: "DocumentFileStorageService.blobSize")
                 throw ModelError.documentStorageFailed(reason: error.localizedDescription)
             }
             logger.exit("blobSize", duration: ContinuousClock.now - start)

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/LaunchOrphanCleanupCoordinator.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/LaunchOrphanCleanupCoordinator.swift
@@ -1,0 +1,111 @@
+import CryptoKit
+import Foundation
+
+/// Runs orphan blob cleanup at app launch for every accessible person.
+///
+/// Extracted from `MainAppView.task` so the logic is testable in isolation —
+/// `.task` modifiers cannot be exercised by unit tests. The coordinator is
+/// best-effort and silent: failures are logged but do not surface in the UI,
+/// and per-person failures never block their siblings.
+final class LaunchOrphanCleanupCoordinator: Sendable {
+    // MARK: - Dependencies
+
+    private let cleanupService: OrphanBlobCleanupServiceProtocol
+    private let personRepository: PersonRepositoryProtocol
+    private let primaryKeyProvider: PrimaryKeyProviderProtocol
+    private let logger: TracingCategoryLogger
+
+    // MARK: - Initialization
+
+    init(
+        cleanupService: OrphanBlobCleanupServiceProtocol,
+        personRepository: PersonRepositoryProtocol,
+        primaryKeyProvider: PrimaryKeyProviderProtocol,
+        logger: CategoryLoggerProtocol? = nil
+    ) {
+        self.cleanupService = cleanupService
+        self.personRepository = personRepository
+        self.primaryKeyProvider = primaryKeyProvider
+        self.logger = TracingCategoryLogger(
+            wrapping: logger ?? LoggingService.shared.logger(category: .storage)
+        )
+    }
+
+    // MARK: - Public API
+
+    /// Run cleanup for every accessible person.
+    ///
+    /// Non-fatal by design: if the primary key is unavailable or `fetchAll`
+    /// fails, the method logs and returns silently. If any individual person's
+    /// cleanup throws, the error is logged and the sweep continues with the
+    /// next person.
+    func runCleanup() async {
+        let start = ContinuousClock.now
+        logger.entry("runCleanup")
+
+        let primaryKey: SymmetricKey
+        do {
+            primaryKey = try primaryKeyProvider.getPrimaryKey()
+        } catch {
+            logger.exitWithError("runCleanup", error: error, duration: ContinuousClock.now - start)
+            return
+        }
+
+        let persons: [Person]
+        do {
+            persons = try await personRepository.fetchAll(primaryKey: primaryKey)
+        } catch {
+            logger.exitWithError("runCleanup", error: error, duration: ContinuousClock.now - start)
+            return
+        }
+
+        for person in persons {
+            await cleanupOnePerson(person, primaryKey: primaryKey)
+        }
+
+        logger.exit("runCleanup", duration: ContinuousClock.now - start)
+    }
+
+    // MARK: - Factory
+
+    /// Production wiring that mirrors `SettingsViewModel.DefaultDependencies`
+    /// and `OrphanBlobCleanupService.makeDefault()` so the launch scanner and
+    /// the writer agree on where blobs live.
+    static func makeDefault() -> LaunchOrphanCleanupCoordinator {
+        let coreDataStack = CoreDataStack.shared
+        let encryptionService = EncryptionService()
+        let fmkService = FamilyMemberKeyService()
+        let personRepository = PersonRepository(
+            coreDataStack: coreDataStack,
+            encryptionService: encryptionService,
+            fmkService: fmkService
+        )
+        return LaunchOrphanCleanupCoordinator(
+            cleanupService: OrphanBlobCleanupService.makeDefault(),
+            personRepository: personRepository,
+            primaryKeyProvider: PrimaryKeyProvider()
+        )
+    }
+
+    // MARK: - Private Helpers
+
+    /// Run cleanup for a single person, swallowing errors so siblings keep going.
+    /// Extracted to a helper to keep `runCleanup` flat and its cyclomatic
+    /// complexity low.
+    private func cleanupOnePerson(_ person: Person, primaryKey: SymmetricKey) async {
+        do {
+            let result = try await cleanupService.cleanOrphans(
+                personId: person.id,
+                primaryKey: primaryKey
+            )
+            if result.orphanCount > 0 {
+                logger.info(
+                    "Launch cleanup removed \(result.orphanCount) orphan blobs, freed \(result.freedBytes) bytes"
+                )
+            }
+        } catch {
+            // One person's failure must not block siblings or the UI.
+            logger.logError(error, context: "LaunchOrphanCleanupCoordinator.runCleanup.person")
+        }
+    }
+}

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/LaunchOrphanCleanupCoordinator.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/LaunchOrphanCleanupCoordinator.swift
@@ -60,6 +60,10 @@ final class LaunchOrphanCleanupCoordinator: Sendable {
         }
 
         for person in persons {
+            guard !Task.isCancelled else {
+                logger.debug("Launch cleanup cancelled — aborting remaining persons")
+                break
+            }
             await cleanupOnePerson(person, primaryKey: primaryKey)
         }
 
@@ -89,9 +93,11 @@ final class LaunchOrphanCleanupCoordinator: Sendable {
 
     // MARK: - Private Helpers
 
-    /// Run cleanup for a single person, swallowing errors so siblings keep going.
-    /// Extracted to a helper to keep `runCleanup` flat and its cyclomatic
-    /// complexity low.
+    /// Run cleanup for a single person, swallowing errors so siblings can still be attempted.
+    ///
+    /// Extracted from `runCleanup`'s main loop to make the error-isolation boundary explicit:
+    /// any throw from `cleanOrphans` is logged and absorbed here, so the outer loop always
+    /// advances to the next person.
     private func cleanupOnePerson(_ person: Person, primaryKey: SymmetricKey) async {
         do {
             let result = try await cleanupService.cleanOrphans(
@@ -100,12 +106,13 @@ final class LaunchOrphanCleanupCoordinator: Sendable {
             )
             if result.orphanCount > 0 {
                 logger.info(
-                    "Launch cleanup removed \(result.orphanCount) orphan blobs, freed \(result.freedBytes) bytes"
+                    "Launch cleanup for person \(person.id): removed \(result.orphanCount)" +
+                        " orphan blobs, freed \(result.freedBytes) bytes"
                 )
             }
         } catch {
             // One person's failure must not block siblings or the UI.
-            logger.logError(error, context: "LaunchOrphanCleanupCoordinator.runCleanup.person")
+            logger.logError(error, context: "LaunchOrphanCleanupCoordinator.runCleanup.person[\(person.id)]")
         }
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/LaunchOrphanCleanupCoordinator.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/LaunchOrphanCleanupCoordinator.swift
@@ -39,6 +39,11 @@ final class LaunchOrphanCleanupCoordinator: Sendable {
     /// fails, the method logs and returns silently. If any individual person's
     /// cleanup throws, the error is logged and the sweep continues with the
     /// next person.
+    ///
+    /// Safe to call multiple times per process — SwiftUI's `.task` modifier
+    /// re-fires on every `MainAppView` appearance (cold launch, lock → unlock,
+    /// reauth), and the scan is idempotent: already-referenced blobs are
+    /// skipped, already-deleted blobs are no-ops.
     func runCleanup() async {
         let start = ContinuousClock.now
         logger.entry("runCleanup")

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/OrphanBlobCleanupService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/OrphanBlobCleanupService.swift
@@ -38,7 +38,7 @@ protocol OrphanBlobCleanupServiceProtocol: Sendable {
     func countOrphans(personId: UUID, primaryKey: SymmetricKey) async throws -> CleanupResult
 }
 
-final class OrphanBlobCleanupService: OrphanBlobCleanupServiceProtocol, @unchecked Sendable {
+final class OrphanBlobCleanupService: OrphanBlobCleanupServiceProtocol, Sendable {
     private let blobService: DocumentBlobServiceProtocol
     private let queryService: DocumentReferenceQueryServiceProtocol
     private let logger: TracingCategoryLogger

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/OrphanBlobCleanupService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/OrphanBlobCleanupService.swift
@@ -62,32 +62,14 @@ final class OrphanBlobCleanupService: OrphanBlobCleanupServiceProtocol, Sendable
         logger.entry("cleanOrphans", "personId=\(personId)")
         do {
             let orphans = try await computeOrphans(personId: personId, primaryKey: primaryKey)
-
-            var deletedCount = 0
-            var freedBytes: UInt64 = 0
-            for hmac in orphans {
+            let (count, bytes) = await sumOrphanSizes(orphans, personId: personId) { hmac in
                 // Size first, delete second. If size fails, skip this HMAC and move on —
                 // one bad file shouldn't abort the sweep. Same for a delete failure.
-                let size: UInt64
-                do {
-                    size = try await blobService.blobSize(contentHMAC: hmac, personId: personId)
-                } catch {
-                    logger.logError(error, context: "OrphanBlobCleanupService.cleanOrphans.blobSize")
-                    continue
-                }
-                do {
-                    try await blobService.deleteDirect(contentHMAC: hmac, personId: personId)
-                } catch {
-                    logger.logError(error, context: "OrphanBlobCleanupService.cleanOrphans.deleteDirect")
-                    continue
-                }
-                deletedCount += 1
-                freedBytes += size
+                try await self.blobService.deleteDirect(contentHMAC: hmac, personId: personId)
             }
-
-            logger.debug("cleanOrphans deleted=\(deletedCount), freedBytes=\(freedBytes)")
+            logger.debug("cleanOrphans deleted=\(count), freedBytes=\(bytes)")
             logger.exit("cleanOrphans", duration: ContinuousClock.now - start)
-            return CleanupResult(orphanCount: deletedCount, freedBytes: freedBytes)
+            return CleanupResult(orphanCount: count, freedBytes: bytes)
         } catch {
             logger.exitWithError("cleanOrphans", error: error, duration: ContinuousClock.now - start)
             throw error
@@ -99,24 +81,9 @@ final class OrphanBlobCleanupService: OrphanBlobCleanupServiceProtocol, Sendable
         logger.entry("countOrphans", "personId=\(personId)")
         do {
             let orphans = try await computeOrphans(personId: personId, primaryKey: primaryKey)
-
-            var count = 0
-            var bytes: UInt64 = 0
-            for hmac in orphans {
-                // Match cleanOrphans semantics: a single unreadable file is skipped,
-                // not fatal. The Settings UI would rather show an approximate count
-                // than an error for one bad blob.
-                let size: UInt64
-                do {
-                    size = try await blobService.blobSize(contentHMAC: hmac, personId: personId)
-                } catch {
-                    logger.logError(error, context: "OrphanBlobCleanupService.countOrphans.blobSize")
-                    continue
-                }
-                count += 1
-                bytes += size
-            }
-
+            // Match cleanOrphans semantics: a single unreadable file is skipped, not fatal.
+            // The Settings UI would rather show an approximate count than an error for one bad blob.
+            let (count, bytes) = await sumOrphanSizes(orphans, personId: personId)
             logger.debug("countOrphans count=\(count), bytes=\(bytes)")
             logger.exit("countOrphans", duration: ContinuousClock.now - start)
             return CleanupResult(orphanCount: count, freedBytes: bytes)
@@ -148,6 +115,50 @@ final class OrphanBlobCleanupService: OrphanBlobCleanupServiceProtocol, Sendable
     }
 
     // MARK: - Private
+
+    /// Iterates `orphans`, calls `blobSize` per item (skipping failures), optionally calls a
+    /// caller-supplied per-item action, and returns the `(count, bytes)` totals.
+    ///
+    /// This is the single source of truth for per-HMAC size accounting shared by
+    /// `cleanOrphans` (which passes a `deleteDirect` action) and `countOrphans` (dry-run,
+    /// no action). Keeping the loop here ensures both methods can't drift in their accounting
+    /// logic.
+    ///
+    /// - Parameters:
+    ///   - orphans: HMACs to process.
+    ///   - personId: The person whose blob store is being scanned.
+    ///   - performPerItem: Optional action to run on each HMAC after a successful `blobSize`.
+    ///     If the action throws, the HMAC is skipped and the failure is logged but not rethrown.
+    /// - Returns: `(count, bytes)` where `count` is the number of HMACs successfully processed
+    ///   and `bytes` is the sum of their sizes.
+    private func sumOrphanSizes(
+        _ orphans: [Data],
+        personId: UUID,
+        performPerItem: ((Data) async throws -> Void)? = nil
+    ) async -> (count: Int, bytes: UInt64) {
+        var count = 0
+        var bytes: UInt64 = 0
+        for hmac in orphans {
+            let size: UInt64
+            do {
+                size = try await blobService.blobSize(contentHMAC: hmac, personId: personId)
+            } catch {
+                logger.logError(error, context: "OrphanBlobCleanupService.sumOrphanSizes.blobSize")
+                continue
+            }
+            if let performPerItem {
+                do {
+                    try await performPerItem(hmac)
+                } catch {
+                    logger.logError(error, context: "OrphanBlobCleanupService.sumOrphanSizes.performPerItem")
+                    continue
+                }
+            }
+            count += 1
+            bytes += size
+        }
+        return (count, bytes)
+    }
 
     /// Collect the orphan HMAC set for a person:
     /// `blobsOnDisk - referencedHMACs - inFlight`.

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/OrphanBlobCleanupService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/OrphanBlobCleanupService.swift
@@ -1,0 +1,172 @@
+import CryptoKit
+import Foundation
+
+// swiftformat:disable redundantSendable
+/// Summary of an orphan blob cleanup or dry-run scan.
+///
+/// - `orphanCount`: number of orphan blobs counted (for `countOrphans`) or successfully
+///   deleted (for `cleanOrphans`). Blobs whose size lookup or delete failed are *not*
+///   included — the cleanup is best-effort and partial failures don't poison the report.
+/// - `freedBytes`: bytes that will be (or were) freed by deleting those blobs.
+///
+/// Explicit `Sendable` conformance (instead of relying on inference) so future field
+/// additions can't silently regress cross-actor use.
+struct CleanupResult: Equatable, Sendable {
+    let orphanCount: Int
+    let freedBytes: UInt64
+}
+
+// swiftformat:enable redundantSendable
+
+/// Scans a person's on-disk blobs, computes the set of orphans
+/// (`blobsOnDisk - referencedHMACs - inFlight`), and either deletes them (`cleanOrphans`)
+/// or reports the totals without touching disk (`countOrphans`).
+///
+/// Designed to be safe to run alongside writes: any blob currently marked in-flight by
+/// `DocumentBlobService` is excluded so the cleanup scanner cannot race an active upload.
+/// Partial failures (per-HMAC `blobSize` or `deleteDirect` errors) are logged and skipped
+/// rather than aborting the scan — a single permission/IO blip on one file should not
+/// prevent the rest of the sweep.
+protocol OrphanBlobCleanupServiceProtocol: Sendable {
+    /// Scan and delete orphaned blobs for a single person.
+    /// - Returns: `CleanupResult` with the number of blobs successfully deleted and
+    ///   the total bytes freed. Per-blob failures are logged and omitted from the tally.
+    func cleanOrphans(personId: UUID, primaryKey: SymmetricKey) async throws -> CleanupResult
+
+    /// Dry-run equivalent of `cleanOrphans` for the Settings UI confirmation dialog.
+    /// Does not delete anything; returns the orphan count and bytes that *would* be freed.
+    func countOrphans(personId: UUID, primaryKey: SymmetricKey) async throws -> CleanupResult
+}
+
+final class OrphanBlobCleanupService: OrphanBlobCleanupServiceProtocol, @unchecked Sendable {
+    private let blobService: DocumentBlobServiceProtocol
+    private let queryService: DocumentReferenceQueryServiceProtocol
+    private let logger: TracingCategoryLogger
+
+    init(
+        blobService: DocumentBlobServiceProtocol,
+        queryService: DocumentReferenceQueryServiceProtocol,
+        logger: CategoryLoggerProtocol? = nil
+    ) {
+        self.blobService = blobService
+        self.queryService = queryService
+        self.logger = TracingCategoryLogger(
+            wrapping: logger ?? LoggingService.shared.logger(category: .storage)
+        )
+    }
+
+    // MARK: - OrphanBlobCleanupServiceProtocol
+
+    func cleanOrphans(personId: UUID, primaryKey: SymmetricKey) async throws -> CleanupResult {
+        let start = ContinuousClock.now
+        logger.entry("cleanOrphans", "personId=\(personId)")
+        do {
+            let orphans = try await computeOrphans(personId: personId, primaryKey: primaryKey)
+
+            var deletedCount = 0
+            var freedBytes: UInt64 = 0
+            for hmac in orphans {
+                // Size first, delete second. If size fails, skip this HMAC and move on —
+                // one bad file shouldn't abort the sweep. Same for a delete failure.
+                let size: UInt64
+                do {
+                    size = try await blobService.blobSize(contentHMAC: hmac, personId: personId)
+                } catch {
+                    logger.logError(error, context: "OrphanBlobCleanupService.cleanOrphans.blobSize")
+                    continue
+                }
+                do {
+                    try await blobService.deleteDirect(contentHMAC: hmac, personId: personId)
+                } catch {
+                    logger.logError(error, context: "OrphanBlobCleanupService.cleanOrphans.deleteDirect")
+                    continue
+                }
+                deletedCount += 1
+                freedBytes += size
+            }
+
+            logger.debug("cleanOrphans deleted=\(deletedCount), freedBytes=\(freedBytes)")
+            logger.exit("cleanOrphans", duration: ContinuousClock.now - start)
+            return CleanupResult(orphanCount: deletedCount, freedBytes: freedBytes)
+        } catch {
+            logger.exitWithError("cleanOrphans", error: error, duration: ContinuousClock.now - start)
+            throw error
+        }
+    }
+
+    func countOrphans(personId: UUID, primaryKey: SymmetricKey) async throws -> CleanupResult {
+        let start = ContinuousClock.now
+        logger.entry("countOrphans", "personId=\(personId)")
+        do {
+            let orphans = try await computeOrphans(personId: personId, primaryKey: primaryKey)
+
+            var count = 0
+            var bytes: UInt64 = 0
+            for hmac in orphans {
+                // Match cleanOrphans semantics: a single unreadable file is skipped,
+                // not fatal. The Settings UI would rather show an approximate count
+                // than an error for one bad blob.
+                let size: UInt64
+                do {
+                    size = try await blobService.blobSize(contentHMAC: hmac, personId: personId)
+                } catch {
+                    logger.logError(error, context: "OrphanBlobCleanupService.countOrphans.blobSize")
+                    continue
+                }
+                count += 1
+                bytes += size
+            }
+
+            logger.debug("countOrphans count=\(count), bytes=\(bytes)")
+            logger.exit("countOrphans", duration: ContinuousClock.now - start)
+            return CleanupResult(orphanCount: count, freedBytes: bytes)
+        } catch {
+            logger.exitWithError("countOrphans", error: error, duration: ContinuousClock.now - start)
+            throw error
+        }
+    }
+
+    // MARK: - Factory
+
+    /// Shared default factory for production wiring. Builds its dependencies from the
+    /// same singletons used by `DocumentBlobService.makeDefault()` so the scanner and
+    /// the writer agree on where blobs live.
+    static func makeDefault() -> OrphanBlobCleanupService {
+        let coreDataStack = CoreDataStack.shared
+        let encryptionService = EncryptionService()
+        let recordRepository = MedicalRecordRepository(coreDataStack: coreDataStack)
+        let recordContentService = RecordContentService(encryptionService: encryptionService)
+        let queryService = DocumentReferenceQueryService(
+            recordRepository: recordRepository,
+            recordContentService: recordContentService,
+            fmkService: FamilyMemberKeyService()
+        )
+        return OrphanBlobCleanupService(
+            blobService: DocumentBlobService.makeDefault(),
+            queryService: queryService
+        )
+    }
+
+    // MARK: - Private
+
+    /// Collect the orphan HMAC set for a person:
+    /// `blobsOnDisk - referencedHMACs - inFlight`.
+    ///
+    /// In-flight filtering is async because `DocumentBlobService.isInFlight` hops the
+    /// actor — this is why the function is `async` even though the set math itself isn't.
+    private func computeOrphans(personId: UUID, primaryKey: SymmetricKey) async throws -> [Data] {
+        let onDisk = try await blobService.listBlobs(personId: personId)
+        let referenced = try await queryService.allReferencedHMACs(personId: personId, primaryKey: primaryKey)
+        let unreferenced = onDisk.subtracting(referenced)
+
+        var orphans: [Data] = []
+        orphans.reserveCapacity(unreferenced.count)
+        for hmac in unreferenced {
+            if await blobService.isInFlight(contentHMAC: hmac) {
+                continue
+            }
+            orphans.append(hmac)
+        }
+        return orphans
+    }
+}

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/OrphanBlobCleanupService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/OrphanBlobCleanupService.swift
@@ -62,9 +62,10 @@ final class OrphanBlobCleanupService: OrphanBlobCleanupServiceProtocol, Sendable
         logger.entry("cleanOrphans", "personId=\(personId)")
         do {
             let orphans = try await computeOrphans(personId: personId, primaryKey: primaryKey)
+            // `sumOrphanSizes` enforces size-first ordering and per-HMAC error isolation;
+            // this closure only has to issue the delete. A thrown deleteDirect is logged
+            // and the sweep continues with the next orphan.
             let (count, bytes) = await sumOrphanSizes(orphans, personId: personId) { hmac in
-                // Size first, delete second. If size fails, skip this HMAC and move on —
-                // one bad file shouldn't abort the sweep. Same for a delete failure.
                 try await self.blobService.deleteDirect(contentHMAC: hmac, personId: personId)
             }
             logger.debug("cleanOrphans deleted=\(count), freedBytes=\(bytes)")

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Records/DocumentReferenceQueryService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Records/DocumentReferenceQueryService.swift
@@ -40,6 +40,13 @@ protocol DocumentReferenceQueryServiceProtocol: Sendable {
         personId: UUID,
         primaryKey: SymmetricKey
     ) async throws -> Bool
+
+    /// Returns the set of all contentHMAC values referenced by DocumentReferenceRecords for the person.
+    /// Used by orphan cleanup to compute the set of blobs that are still referenced.
+    func allReferencedHMACs(
+        personId: UUID,
+        primaryKey: SymmetricKey
+    ) async throws -> Set<Data>
 }
 
 final class DocumentReferenceQueryService: DocumentReferenceQueryServiceProtocol, @unchecked Sendable {
@@ -88,6 +95,14 @@ final class DocumentReferenceQueryService: DocumentReferenceQueryServiceProtocol
     ) async throws -> Bool {
         let all = try await fetchAllDocumentReferences(personId: personId, primaryKey: primaryKey)
         return all.contains { $0.recordId != excludingRecordId && $0.content.contentHMAC == contentHMAC }
+    }
+
+    func allReferencedHMACs(
+        personId: UUID,
+        primaryKey: SymmetricKey
+    ) async throws -> Set<Data> {
+        let docs = try await fetchAllDocumentReferences(personId: personId, primaryKey: primaryKey)
+        return Set(docs.map(\.content.contentHMAC))
     }
 
     // MARK: - Private

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/ViewModels/Documents/DocumentPickerViewModel.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/ViewModels/Documents/DocumentPickerViewModel.swift
@@ -181,6 +181,11 @@ final class DocumentPickerViewModel {
     /// Remove a draft. Clears in-flight tracking so the orphan cleanup scan can
     /// reclaim the speculative blob on its next pass. Blob deletion for already-
     /// saved attachments happens via the delete flow instead.
+    ///
+    /// The clearInFlight call is dispatched asynchronously from a fire-and-forget
+    /// Task, so a cleanup scan that runs between `removeDraft` and the clear landing
+    /// will still skip the blob on that pass. This is self-healing: the very next
+    /// scan will see the HMAC is no longer in-flight and reclaim it.
     func removeDraft(id: UUID) {
         guard let index = drafts.firstIndex(where: { $0.id == id }) else { return }
         let hmac = drafts[index].content.contentHMAC
@@ -196,6 +201,12 @@ final class DocumentPickerViewModel {
     /// Exposed so `GenericRecordFormViewModel` can release in-flight state after
     /// persisting each attachment record, without reaching into the blob service
     /// directly.
+    ///
+    /// Do NOT call this on form cancellation or save failure — use `removeDraft`
+    /// instead, which preserves retry semantics by keeping the blob on disk for a
+    /// subsequent save attempt. Calling `clearInFlightForDraft` without having
+    /// persisted the referencing record leaves the blob unprotected against the
+    /// next cleanup scan.
     func clearInFlightForDraft(contentHMAC: Data) async {
         await blobService.clearInFlight(contentHMAC: contentHMAC)
     }
@@ -244,15 +255,15 @@ final class DocumentPickerViewModel {
     }
 
     private func storeAndAppend(plaintext: Data, title: TitleStrategy) async throws {
+        // `store` atomically marks the resulting HMAC as in-flight on the blob actor,
+        // so the orphan cleanup scanner cannot observe the on-disk blob without also
+        // observing the in-flight bit. The in-flight state is released on successful
+        // record save (via `clearInFlightForDraft`) or on draft removal.
         let stored = try await blobService.store(
             plaintext: plaintext,
             personId: personId,
             primaryKey: primaryKey
         )
-        // Mark the blob as in-flight so the orphan cleanup scan doesn't reclaim it
-        // between now and the form saving the DocumentReferenceRecord. Cleared on
-        // successful record save (via clearInFlightForDraft) or draft removal.
-        await blobService.markInFlight(contentHMAC: stored.contentHMAC)
         let finalTitle: String = switch title {
         case let .verbatim(name):
             name

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/ViewModels/Documents/DocumentPickerViewModel.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/ViewModels/Documents/DocumentPickerViewModel.swift
@@ -178,9 +178,26 @@ final class DocumentPickerViewModel {
         isLoading = false
     }
 
-    /// Remove a draft. Blob orphan cleanup happens via the delete flow later.
+    /// Remove a draft. Clears in-flight tracking so the orphan cleanup scan can
+    /// reclaim the speculative blob on its next pass. Blob deletion for already-
+    /// saved attachments happens via the delete flow instead.
     func removeDraft(id: UUID) {
-        drafts.removeAll { $0.id == id }
+        guard let index = drafts.firstIndex(where: { $0.id == id }) else { return }
+        let hmac = drafts[index].content.contentHMAC
+        drafts.remove(at: index)
+        // Fire-and-forget: removeDraft is called from the UI and shouldn't become
+        // async just for this side effect. Tests await briefly to observe the clear.
+        Task {
+            await blobService.clearInFlight(contentHMAC: hmac)
+        }
+    }
+
+    /// Clear in-flight tracking for a draft's blob after its record has been saved.
+    /// Exposed so `GenericRecordFormViewModel` can release in-flight state after
+    /// persisting each attachment record, without reaching into the blob service
+    /// directly.
+    func clearInFlightForDraft(contentHMAC: Data) async {
+        await blobService.clearInFlight(contentHMAC: contentHMAC)
     }
 
     /// Update a draft's title.
@@ -232,6 +249,10 @@ final class DocumentPickerViewModel {
             personId: personId,
             primaryKey: primaryKey
         )
+        // Mark the blob as in-flight so the orphan cleanup scan doesn't reclaim it
+        // between now and the form saving the DocumentReferenceRecord. Cleared on
+        // successful record save (via clearInFlightForDraft) or draft removal.
+        await blobService.markInFlight(contentHMAC: stored.contentHMAC)
         let finalTitle: String = switch title {
         case let .verbatim(name):
             name

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/ViewModels/Records/GenericRecordFormViewModel.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/ViewModels/Records/GenericRecordFormViewModel.swift
@@ -352,6 +352,10 @@ final class GenericRecordFormViewModel {
                 let encrypted = try recordContentService.encrypt(attachEnvelope, using: fmk)
                 let attachRecord = MedicalRecord(personId: person.id, encryptedContent: encrypted)
                 try await medicalRecordRepository.save(attachRecord)
+                // Record saved successfully — the blob is no longer speculative, so the
+                // orphan cleanup scan can treat it as a normal reference. A failed save
+                // intentionally leaves the HMAC in-flight so a retry still finds its blob.
+                await pickerVM.clearInFlightForDraft(contentHMAC: docRef.contentHMAC)
             } catch {
                 errorMessage = "Record saved, but some attachments could not be saved."
                 logger.logError(error, context: "GenericRecordFormViewModel.saveAttachmentDrafts")

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/ViewModels/Records/GenericRecordFormViewModel.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/ViewModels/Records/GenericRecordFormViewModel.swift
@@ -355,8 +355,16 @@ final class GenericRecordFormViewModel {
                 // Record saved successfully — the blob is no longer speculative, so the
                 // orphan cleanup scan can treat it as a normal reference. A failed save
                 // intentionally leaves the HMAC in-flight so a retry still finds its blob.
+                //
+                // Edge case: if the user abandons the form after a partial-failure save
+                // (some attachments cleared, others still in-flight), the leftover
+                // in-flight entries persist until process exit. That's a process-local
+                // leak, not a disk leak — the next launch's cleanup scan reclaims the
+                // blob once the in-flight set is re-initialized empty. Acceptable for
+                // the sake of preserving retry semantics on the common path.
                 await pickerVM.clearInFlightForDraft(contentHMAC: docRef.contentHMAC)
             } catch {
+                // Intentionally do NOT clearInFlight here — see success branch comment.
                 errorMessage = "Record saved, but some attachments could not be saved."
                 logger.logError(error, context: "GenericRecordFormViewModel.saveAttachmentDrafts")
             }

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/ViewModels/Records/MedicalRecordListViewModel.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/ViewModels/Records/MedicalRecordListViewModel.swift
@@ -196,6 +196,7 @@ final class MedicalRecordListViewModel {
                     }
                     try await blobService.deleteIfUnreferenced(
                         contentHMAC: attachment.content.contentHMAC,
+                        personId: person.id,
                         isReferencedElsewhere: isReferencedElsewhere
                     )
                 } else {

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Views/Auth/AuthenticationCoordinatorView.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Views/Auth/AuthenticationCoordinatorView.swift
@@ -77,10 +77,16 @@ struct MainAppView: View {
     @State private var primaryKeyError: String?
 
     private let primaryKeyProvider: PrimaryKeyProviderProtocol
+    private let launchCleanup: LaunchOrphanCleanupCoordinator
 
-    init(viewModel: AuthenticationViewModel, primaryKeyProvider: PrimaryKeyProviderProtocol = PrimaryKeyProvider()) {
+    init(
+        viewModel: AuthenticationViewModel,
+        primaryKeyProvider: PrimaryKeyProviderProtocol = PrimaryKeyProvider(),
+        launchCleanup: LaunchOrphanCleanupCoordinator = LaunchOrphanCleanupCoordinator.makeDefault()
+    ) {
         self.viewModel = viewModel
         self.primaryKeyProvider = primaryKeyProvider
+        self.launchCleanup = launchCleanup
     }
 
     var body: some View {
@@ -138,6 +144,9 @@ struct MainAppView: View {
                     Task {
                         await viewModel.exitDemoMode()
                     }
+                }
+                .task {
+                    await launchCleanup.runCleanup()
                 }
         }
     }

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Views/Settings/SettingsView.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Views/Settings/SettingsView.swift
@@ -17,6 +17,7 @@ struct SettingsView: View {
                     demoModeSection
                 }
                 backupSection
+                storageManagementSection
                 diagnosticLogsSection
             }
             .navigationTitle("Settings")
@@ -92,6 +93,35 @@ struct SettingsView: View {
             } message: {
                 Text("All demo data will be deleted. You'll return to the welcome screen.")
             }
+            .alert("Clean Up Storage?", isPresented: $viewModel.showingCleanupConfirmation) {
+                Button("Clean Up", role: .destructive) {
+                    Task {
+                        await viewModel.performCleanup(primaryKey: primaryKey)
+                    }
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                if let result = viewModel.cleanupDryRunResult {
+                    Text(
+                        "Found \(result.orphanCount) orphaned file\(result.orphanCount == 1 ? "" : "s") "
+                            + "(\(viewModel.formattedCleanupSize)). Clean up?"
+                    )
+                }
+            }
+            .alert("Storage Cleanup", isPresented: $viewModel.showingCleanupResult) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                if let result = viewModel.cleanupResult {
+                    if result.orphanCount > 0 {
+                        Text(
+                            "Freed \(viewModel.formattedCleanupSize) from "
+                                + "\(result.orphanCount) orphaned file\(result.orphanCount == 1 ? "" : "s")."
+                        )
+                    } else {
+                        Text("No orphaned files found.")
+                    }
+                }
+            }
             .onChange(of: viewModel.demoModeExited) { _, exited in
                 if exited {
                     dismiss()
@@ -139,6 +169,30 @@ struct SettingsView: View {
             Text("Backup & Restore")
         } footer: {
             Text("Export your data to a secure backup file, or restore from a previous backup.")
+        }
+    }
+
+    private var storageManagementSection: some View {
+        Section {
+            Button {
+                Task {
+                    await viewModel.checkStorage(primaryKey: primaryKey)
+                }
+            } label: {
+                HStack {
+                    Label("Clean Up Storage", systemImage: "trash.circle")
+                    Spacer()
+                    if viewModel.isCheckingStorage || viewModel.isCleaningStorage {
+                        ProgressView()
+                    }
+                }
+            }
+            .disabled(viewModel.isCheckingStorage || viewModel.isCleaningStorage)
+            .accessibilityIdentifier("cleanUpStorageButton")
+        } header: {
+            Text("Storage Management")
+        } footer: {
+            Text("Remove orphaned attachment files that are no longer referenced by any record.")
         }
     }
 

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Views/Settings/SettingsView.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Views/Settings/SettingsView.swift
@@ -102,10 +102,11 @@ struct SettingsView: View {
                 Button("Cancel", role: .cancel) {}
             } message: {
                 if let result = viewModel.cleanupDryRunResult {
-                    Text(
-                        "Found \(result.orphanCount) orphaned file\(result.orphanCount == 1 ? "" : "s") "
-                            + "(\(viewModel.formattedCleanupSize)). Clean up?"
+                    let size = ByteCountFormatter.string(
+                        fromByteCount: Int64(result.freedBytes), countStyle: .file
                     )
+                    let plural = result.orphanCount == 1 ? "" : "s"
+                    Text("Found \(result.orphanCount) orphaned file\(plural) (\(size)). Clean up?")
                 }
             }
             .alert("Storage Cleanup", isPresented: $viewModel.showingCleanupResult) {
@@ -113,10 +114,11 @@ struct SettingsView: View {
             } message: {
                 if let result = viewModel.cleanupResult {
                     if result.orphanCount > 0 {
-                        Text(
-                            "Freed \(viewModel.formattedCleanupSize) from "
-                                + "\(result.orphanCount) orphaned file\(result.orphanCount == 1 ? "" : "s")."
+                        let size = ByteCountFormatter.string(
+                            fromByteCount: Int64(result.freedBytes), countStyle: .file
                         )
+                        let plural = result.orphanCount == 1 ? "" : "s"
+                        Text("Freed \(size) from \(result.orphanCount) orphaned file\(plural).")
                     } else {
                         Text("No orphaned files found.")
                     }

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Views/Settings/SettingsViewModel.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Views/Settings/SettingsViewModel.swift
@@ -507,14 +507,6 @@ extension SettingsViewModel {
 
         isCleaningStorage = false
     }
-
-    /// Human-readable string for the current dry-run or cleanup result. Prefers the
-    /// dry-run result if both are present so the confirmation dialog and its subsequent
-    /// result alert can read from the same computed property.
-    var formattedCleanupSize: String {
-        guard let result = cleanupDryRunResult ?? cleanupResult else { return "" }
-        return ByteCountFormatter.string(fromByteCount: Int64(result.freedBytes), countStyle: .file)
-    }
 }
 
 // MARK: - Demo Mode Notifications

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Views/Settings/SettingsViewModel.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Views/Settings/SettingsViewModel.swift
@@ -14,6 +14,8 @@ final class SettingsViewModel {
     private let passwordValidationService: PasswordValidationServiceProtocol
     private let demoModeService: DemoModeServiceProtocol
     private let logExportService: LogExportServiceProtocol
+    private let cleanupService: OrphanBlobCleanupServiceProtocol
+    private let personRepository: PersonRepositoryProtocol
     private let logger: CategoryLoggerProtocol
 
     // MARK: - Export State
@@ -53,6 +55,15 @@ final class SettingsViewModel {
     var logExportState: LogExportState = .idle
     var exportedLogURL: URL?
     var showingLogShareSheet = false
+
+    // MARK: - Storage Cleanup State
+
+    var isCheckingStorage = false
+    var isCleaningStorage = false
+    var showingCleanupConfirmation = false
+    var showingCleanupResult = false
+    var cleanupDryRunResult: CleanupResult?
+    var cleanupResult: CleanupResult?
 
     enum LogExportState: Equatable {
         case idle
@@ -96,6 +107,8 @@ final class SettingsViewModel {
         passwordValidationService: PasswordValidationServiceProtocol = PasswordValidationService(),
         demoModeService: DemoModeServiceProtocol = DemoModeService(),
         logExportService: LogExportServiceProtocol? = nil,
+        cleanupService: OrphanBlobCleanupServiceProtocol? = nil,
+        personRepository: PersonRepositoryProtocol? = nil,
         logger: CategoryLoggerProtocol? = nil
     ) {
         self.exportService = exportService
@@ -104,6 +117,8 @@ final class SettingsViewModel {
         self.passwordValidationService = passwordValidationService
         self.demoModeService = demoModeService
         self.logExportService = logExportService ?? LogExportService()
+        self.cleanupService = cleanupService ?? OrphanBlobCleanupService.makeDefault()
+        self.personRepository = personRepository ?? DefaultDependencies().personRepository
         self.logger = logger ?? LoggingService.shared.logger(category: .storage)
     }
 
@@ -113,7 +128,8 @@ final class SettingsViewModel {
         return SettingsViewModel(
             exportService: deps.exportService,
             importService: deps.importService,
-            backupFileService: deps.backupFileService
+            backupFileService: deps.backupFileService,
+            personRepository: deps.personRepository
         )
     }
 }
@@ -125,6 +141,7 @@ private struct DefaultDependencies {
     let exportService: ExportServiceProtocol
     let importService: ImportServiceProtocol
     let backupFileService: BackupFileServiceProtocol
+    let personRepository: PersonRepositoryProtocol
 
     init() {
         let coreDataStack = CoreDataStack.shared
@@ -136,6 +153,7 @@ private struct DefaultDependencies {
             encryptionService: encryptionService,
             fmkService: fmkService
         )
+        self.personRepository = personRepository
         let recordRepository = MedicalRecordRepository(coreDataStack: coreDataStack)
         let recordContentService = RecordContentService(encryptionService: encryptionService)
         let providerRepository = ProviderRepository(
@@ -418,6 +436,84 @@ extension SettingsViewModel {
             logger.logError(error, context: "SettingsViewModel.exportDiagnosticLogs")
             logExportState = .error(error.localizedDescription)
         }
+    }
+}
+
+// MARK: - Storage Cleanup
+
+extension SettingsViewModel {
+    /// Run a dry-run orphan scan across all persons. If any orphans are found, surface
+    /// the confirmation dialog; otherwise show a result alert immediately.
+    func checkStorage(primaryKey: SymmetricKey) async {
+        isCheckingStorage = true
+        cleanupDryRunResult = nil
+        cleanupResult = nil
+        errorMessage = nil
+
+        do {
+            let persons = try await personRepository.fetchAll(primaryKey: primaryKey)
+            var totalOrphans = 0
+            var totalBytes: UInt64 = 0
+            for person in persons {
+                let result = try await cleanupService.countOrphans(
+                    personId: person.id,
+                    primaryKey: primaryKey
+                )
+                totalOrphans += result.orphanCount
+                totalBytes += result.freedBytes
+            }
+            let aggregate = CleanupResult(orphanCount: totalOrphans, freedBytes: totalBytes)
+            cleanupDryRunResult = aggregate
+
+            if aggregate.orphanCount > 0 {
+                showingCleanupConfirmation = true
+            } else {
+                cleanupResult = aggregate
+                showingCleanupResult = true
+            }
+        } catch {
+            logger.logError(error, context: "SettingsViewModel.checkStorage")
+            errorMessage = "Unable to check storage. Please try again."
+        }
+
+        isCheckingStorage = false
+    }
+
+    /// Actually delete orphaned blobs for every person. Aggregates counts across persons
+    /// and surfaces the total in the result alert.
+    func performCleanup(primaryKey: SymmetricKey) async {
+        isCleaningStorage = true
+        errorMessage = nil
+        showingCleanupConfirmation = false
+
+        do {
+            let persons = try await personRepository.fetchAll(primaryKey: primaryKey)
+            var totalOrphans = 0
+            var totalBytes: UInt64 = 0
+            for person in persons {
+                let result = try await cleanupService.cleanOrphans(
+                    personId: person.id,
+                    primaryKey: primaryKey
+                )
+                totalOrphans += result.orphanCount
+                totalBytes += result.freedBytes
+            }
+            cleanupResult = CleanupResult(orphanCount: totalOrphans, freedBytes: totalBytes)
+            showingCleanupResult = true
+        } catch {
+            logger.logError(error, context: "SettingsViewModel.performCleanup")
+            errorMessage = "Some files could not be cleaned up."
+        }
+
+        isCleaningStorage = false
+    }
+
+    /// Human-readable string for the current dry-run or cleanup result. Prefers the
+    /// dry-run result if both are present so the confirmation dialog and its subsequent
+    /// result alert can read from the same computed property.
+    var formattedCleanupSize: String {
+        guard let result = cleanupDryRunResult ?? cleanupResult else { return "" }
+        return ByteCountFormatter.string(fromByteCount: Int64(result.freedBytes), countStyle: .file)
     }
 }
 

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Views/Settings/SettingsViewModel.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Views/Settings/SettingsViewModel.swift
@@ -485,6 +485,9 @@ extension SettingsViewModel {
         isCleaningStorage = true
         errorMessage = nil
         showingCleanupConfirmation = false
+        // Drop the stale dry-run so a future alert body that reads cleanupDryRunResult
+        // after cleanup cannot display a pre-cleanup number next to a post-cleanup one.
+        cleanupDryRunResult = nil
 
         do {
             let persons = try await personRepository.fetchAll(primaryKey: primaryKey)

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockDocumentBlobService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockDocumentBlobService.swift
@@ -47,10 +47,16 @@ final class MockDocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sen
     var retrieveError: Error?
     var deleteError: Error?
     var deleteDirectError: Error?
+    var listBlobsError: Error?
+    var blobSizeError: Error?
 
     /// HMACs for which deleteDirect should throw. Overrides deleteDirectError
     /// when set. Used to simulate partial failures in cleanup tests (Task 4).
     var deleteDirectFailForHMACs: Set<Data> = []
+
+    /// HMACs for which blobSize should throw. Mirrors deleteDirectFailForHMACs pattern
+    /// for per-HMAC error injection in cleanup tests.
+    var blobSizeFailForHMACs: Set<Data> = []
 
     // MARK: - In-Flight State for Tests
 
@@ -127,13 +133,22 @@ final class MockDocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sen
 
     // MARK: - Cleanup Support
 
-    func listBlobs(personId: UUID) async -> Set<Data> {
+    func listBlobs(personId: UUID) async throws -> Set<Data> {
         listBlobsCalls.append(personId)
+        if let listBlobsError {
+            throw listBlobsError
+        }
         return blobsOnDisk[personId] ?? []
     }
 
-    func blobSize(contentHMAC: Data, personId: UUID) async -> UInt64 {
+    func blobSize(contentHMAC: Data, personId: UUID) async throws -> UInt64 {
         blobSizeCalls.append(BlobLookup(contentHMAC: contentHMAC, personId: personId))
+        if let blobSizeError {
+            throw blobSizeError
+        }
+        if blobSizeFailForHMACs.contains(contentHMAC) {
+            throw ModelError.documentStorageFailed(reason: "Mock per-hmac blobSize failure")
+        }
         return blobSizes[contentHMAC] ?? 1_024
     }
 
@@ -187,6 +202,9 @@ final class MockDocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sen
         deleteError = nil
         deleteDirectError = nil
         deleteDirectFailForHMACs.removeAll()
+        listBlobsError = nil
+        blobSizeError = nil
+        blobSizeFailForHMACs.removeAll()
 
         inFlightHMACs.removeAll()
         blobsOnDisk.removeAll()

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockDocumentBlobService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockDocumentBlobService.swift
@@ -86,11 +86,16 @@ final class MockDocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sen
         if let storeError {
             throw storeError
         }
+        // Mirror the real DocumentBlobService contract: `store` marks its HMAC in-flight
+        // atomically as part of the same call, so viewmodel tests running against the
+        // mock observe the same in-flight state they would against the real actor.
         if let storeResult {
+            inFlightHMACs.insert(storeResult.contentHMAC)
             return storeResult
         }
         let hmac = Data(SHA256.hash(data: plaintext))
         let thumbnail: Data? = detectedMimeStub.lowercased().hasPrefix("image/") ? Data([0xAA, 0xBB]) : nil
+        inFlightHMACs.insert(hmac)
         return DocumentBlobService.StoredBlob(
             contentHMAC: hmac,
             encryptedSize: plaintext.count,

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockDocumentBlobService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockDocumentBlobService.swift
@@ -13,9 +13,17 @@ final class MockDocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sen
         let personId: UUID
     }
 
+    /// Records each call to `deleteIfUnreferenced`. Named struct (not a tuple) to
+    /// satisfy SwiftLint `large_tuple` and to give assertions readable field names.
+    struct DeleteIfUnreferencedCall: Equatable {
+        let contentHMAC: Data
+        let personId: UUID
+        let isReferencedElsewhere: Bool
+    }
+
     var storeCalls: [StoreCall] = []
     var retrieveCalls: [Data] = []
-    var deleteCalls: [Data] = []
+    var deleteCalls: [DeleteIfUnreferencedCall] = []
 
     var storeResult: DocumentBlobService.StoredBlob?
     var storeError: Error?
@@ -62,9 +70,19 @@ final class MockDocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sen
         return retrieveResult ?? Data()
     }
 
-    func deleteIfUnreferenced(contentHMAC: Data, isReferencedElsewhere: Bool) async throws {
+    func deleteIfUnreferenced(
+        contentHMAC: Data,
+        personId: UUID,
+        isReferencedElsewhere: Bool
+    ) async throws {
         guard !isReferencedElsewhere else { return }
-        deleteCalls.append(contentHMAC)
+        deleteCalls.append(
+            DeleteIfUnreferencedCall(
+                contentHMAC: contentHMAC,
+                personId: personId,
+                isReferencedElsewhere: isReferencedElsewhere
+            )
+        )
         if let deleteError {
             throw deleteError
         }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockDocumentBlobService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockDocumentBlobService.swift
@@ -21,20 +21,55 @@ final class MockDocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sen
         let isReferencedElsewhere: Bool
     }
 
+    /// Shared shape for the cleanup-path lookups (blobSize / deleteDirect).
+    struct BlobLookup: Equatable {
+        let contentHMAC: Data
+        let personId: UUID
+    }
+
+    // MARK: - Call Tracking
+
     var storeCalls: [StoreCall] = []
     var retrieveCalls: [Data] = []
     var deleteCalls: [DeleteIfUnreferencedCall] = []
+    var deleteDirectCalls: [BlobLookup] = []
+    var listBlobsCalls: [UUID] = []
+    var blobSizeCalls: [BlobLookup] = []
+    var markInFlightCalls: [Data] = []
+    var clearInFlightCalls: [Data] = []
+    var isInFlightCalls: [Data] = []
+
+    // MARK: - Result / Error Stubs
 
     var storeResult: DocumentBlobService.StoredBlob?
     var storeError: Error?
     var retrieveResult: Data?
     var retrieveError: Error?
     var deleteError: Error?
+    var deleteDirectError: Error?
+
+    /// HMACs for which deleteDirect should throw. Overrides deleteDirectError
+    /// when set. Used to simulate partial failures in cleanup tests (Task 4).
+    var deleteDirectFailForHMACs: Set<Data> = []
+
+    // MARK: - In-Flight State for Tests
+
+    var inFlightHMACs: Set<Data> = []
+
+    // MARK: - Cleanup Test State
+
+    /// Blobs on disk per person, consulted by `listBlobs`.
+    var blobsOnDisk: [UUID: Set<Data>] = [:]
+
+    /// Blob sizes returned by `blobSize`. Unknown HMACs fall back to 1024.
+    var blobSizes: [Data: UInt64] = [:]
 
     /// MIME the mock reports as `detectedMimeType` in the synthesized StoredBlob when
     /// no explicit `storeResult` is set. Defaults to `image/jpeg` so existing fixtures
     /// that just check "was store called" still get a plausible result.
     var detectedMimeStub: String = "image/jpeg"
+
+    // MARK: - DocumentBlobServiceProtocol
 
     func store(
         plaintext: Data,
@@ -88,5 +123,74 @@ final class MockDocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sen
         if let deleteError {
             throw deleteError
         }
+    }
+
+    // MARK: - Cleanup Support
+
+    func listBlobs(personId: UUID) async -> Set<Data> {
+        listBlobsCalls.append(personId)
+        return blobsOnDisk[personId] ?? []
+    }
+
+    func blobSize(contentHMAC: Data, personId: UUID) async -> UInt64 {
+        blobSizeCalls.append(BlobLookup(contentHMAC: contentHMAC, personId: personId))
+        return blobSizes[contentHMAC] ?? 1_024
+    }
+
+    func deleteDirect(contentHMAC: Data, personId: UUID) async throws {
+        deleteDirectCalls.append(BlobLookup(contentHMAC: contentHMAC, personId: personId))
+        if deleteDirectFailForHMACs.contains(contentHMAC) {
+            throw ModelError.documentStorageFailed(reason: "Mock per-hmac failure")
+        }
+        if let deleteDirectError {
+            throw deleteDirectError
+        }
+        blobsOnDisk[personId]?.remove(contentHMAC)
+    }
+
+    // MARK: - In-Flight Tracking
+
+    func markInFlight(contentHMAC: Data) async {
+        markInFlightCalls.append(contentHMAC)
+        inFlightHMACs.insert(contentHMAC)
+    }
+
+    func clearInFlight(contentHMAC: Data) async {
+        clearInFlightCalls.append(contentHMAC)
+        inFlightHMACs.remove(contentHMAC)
+    }
+
+    func isInFlight(contentHMAC: Data) async -> Bool {
+        isInFlightCalls.append(contentHMAC)
+        return inFlightHMACs.contains(contentHMAC)
+    }
+
+    // MARK: - Test Helpers
+
+    /// Reset every recorded call, stubbed result, and mutable state field so a
+    /// single mock instance can be shared across tests without leakage.
+    func reset() {
+        storeCalls.removeAll()
+        retrieveCalls.removeAll()
+        deleteCalls.removeAll()
+        deleteDirectCalls.removeAll()
+        listBlobsCalls.removeAll()
+        blobSizeCalls.removeAll()
+        markInFlightCalls.removeAll()
+        clearInFlightCalls.removeAll()
+        isInFlightCalls.removeAll()
+
+        storeResult = nil
+        storeError = nil
+        retrieveResult = nil
+        retrieveError = nil
+        deleteError = nil
+        deleteDirectError = nil
+        deleteDirectFailForHMACs.removeAll()
+
+        inFlightHMACs.removeAll()
+        blobsOnDisk.removeAll()
+        blobSizes.removeAll()
+        detectedMimeStub = "image/jpeg"
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockDocumentBlobService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockDocumentBlobService.swift
@@ -75,7 +75,8 @@ final class MockDocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sen
         personId: UUID,
         isReferencedElsewhere: Bool
     ) async throws {
-        guard !isReferencedElsewhere else { return }
+        // Record the call regardless of the guard so tests can assert on
+        // intended-preserve paths with the same instrumentation as delete paths.
         deleteCalls.append(
             DeleteIfUnreferencedCall(
                 contentHMAC: contentHMAC,
@@ -83,6 +84,7 @@ final class MockDocumentBlobService: DocumentBlobServiceProtocol, @unchecked Sen
                 isReferencedElsewhere: isReferencedElsewhere
             )
         )
+        guard !isReferencedElsewhere else { return }
         if let deleteError {
             throw deleteError
         }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockDocumentFileStorageService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockDocumentFileStorageService.swift
@@ -1,11 +1,24 @@
 import Foundation
 @testable import FamilyMedicalApp
 
-/// Mock implementation of DocumentFileStorageService for testing
+/// Mock implementation of DocumentFileStorageService for testing.
+/// Storage is keyed by `"{personId}/{hmacHex}"` to mirror the per-person subdirectory layout.
 final class MockDocumentFileStorageService: DocumentFileStorageServiceProtocol, @unchecked Sendable {
+    // MARK: - Call Record Types
+
+    struct StoreCall: Equatable {
+        let encryptedData: Data
+        let contentHMAC: Data
+        let personId: UUID
+    }
+
+    struct HMACPersonCall: Equatable {
+        let contentHMAC: Data
+        let personId: UUID
+    }
+
     // MARK: - State
 
-    /// In-memory storage keyed by HMAC hex string
     private var storage: [String: Data] = [:]
 
     // MARK: - Configuration
@@ -13,58 +26,79 @@ final class MockDocumentFileStorageService: DocumentFileStorageServiceProtocol, 
     var shouldFailStore = false
     var shouldFailRetrieve = false
     var shouldFailDelete = false
+    var shouldFailListBlobs = false
 
     // MARK: - Call Tracking
 
-    var storeCalls: [(encryptedData: Data, contentHMAC: Data)] = []
-    var retrieveCalls: [Data] = []
-    var deleteCalls: [Data] = []
-    var existsCalls: [Data] = []
+    var storeCalls: [StoreCall] = []
+    var retrieveCalls: [HMACPersonCall] = []
+    var deleteCalls: [HMACPersonCall] = []
+    var existsCalls: [HMACPersonCall] = []
+    var listBlobsCalls: [UUID] = []
+    var blobSizeCalls: [HMACPersonCall] = []
 
     // MARK: - DocumentFileStorageServiceProtocol
 
-    func store(encryptedData: Data, contentHMAC: Data) throws -> URL {
-        storeCalls.append((encryptedData, contentHMAC))
-
+    func store(encryptedData: Data, contentHMAC: Data, personId: UUID) throws -> URL {
+        storeCalls.append(StoreCall(encryptedData: encryptedData, contentHMAC: contentHMAC, personId: personId))
         if shouldFailStore {
             throw ModelError.documentStorageFailed(reason: "Mock store failure")
         }
-
-        let key = hmacKey(contentHMAC)
+        let key = storageKey(personId: personId, hmac: contentHMAC)
         storage[key] = encryptedData
-        return URL(fileURLWithPath: "/mock/attachments/\(key).enc")
+        return URL(fileURLWithPath: "/mock/attachments/\(personId.uuidString)/\(hmacHex(contentHMAC)).enc")
     }
 
-    func retrieve(contentHMAC: Data) throws -> Data {
-        retrieveCalls.append(contentHMAC)
-
+    func retrieve(contentHMAC: Data, personId: UUID) throws -> Data {
+        retrieveCalls.append(HMACPersonCall(contentHMAC: contentHMAC, personId: personId))
         if shouldFailRetrieve {
             throw ModelError.documentContentCorrupted
         }
-
-        let key = hmacKey(contentHMAC)
+        let key = storageKey(personId: personId, hmac: contentHMAC)
         guard let data = storage[key] else {
             throw ModelError.documentNotFound()
         }
-
         return data
     }
 
-    func delete(contentHMAC: Data) throws {
-        deleteCalls.append(contentHMAC)
-
+    func delete(contentHMAC: Data, personId: UUID) throws {
+        deleteCalls.append(HMACPersonCall(contentHMAC: contentHMAC, personId: personId))
         if shouldFailDelete {
             throw ModelError.documentStorageFailed(reason: "Mock delete failure")
         }
-
-        let key = hmacKey(contentHMAC)
+        let key = storageKey(personId: personId, hmac: contentHMAC)
         storage.removeValue(forKey: key)
     }
 
-    func exists(contentHMAC: Data) -> Bool {
-        existsCalls.append(contentHMAC)
-        let key = hmacKey(contentHMAC)
+    func exists(contentHMAC: Data, personId: UUID) -> Bool {
+        existsCalls.append(HMACPersonCall(contentHMAC: contentHMAC, personId: personId))
+        let key = storageKey(personId: personId, hmac: contentHMAC)
         return storage[key] != nil
+    }
+
+    func listBlobs(personId: UUID) throws -> Set<Data> {
+        listBlobsCalls.append(personId)
+        if shouldFailListBlobs {
+            throw ModelError.documentStorageFailed(reason: "Mock listBlobs failure")
+        }
+        let prefix = personId.uuidString + "/"
+        var hmacs = Set<Data>()
+        for key in storage.keys where key.hasPrefix(prefix) {
+            let hexPart = String(key.dropFirst(prefix.count))
+            if let hmac = dataFromHex(hexPart) {
+                hmacs.insert(hmac)
+            }
+        }
+        return hmacs
+    }
+
+    func blobSize(contentHMAC: Data, personId: UUID) throws -> UInt64 {
+        blobSizeCalls.append(HMACPersonCall(contentHMAC: contentHMAC, personId: personId))
+        let key = storageKey(personId: personId, hmac: contentHMAC)
+        guard let data = storage[key] else {
+            throw ModelError.documentNotFound()
+        }
+        return UInt64(data.count)
     }
 
     // MARK: - Test Helpers
@@ -75,18 +109,40 @@ final class MockDocumentFileStorageService: DocumentFileStorageServiceProtocol, 
         retrieveCalls.removeAll()
         deleteCalls.removeAll()
         existsCalls.removeAll()
+        listBlobsCalls.removeAll()
+        blobSizeCalls.removeAll()
         shouldFailStore = false
         shouldFailRetrieve = false
         shouldFailDelete = false
+        shouldFailListBlobs = false
     }
 
     /// Pre-populate storage for testing retrieval
-    func addTestData(_ data: Data, forHMAC hmac: Data) {
-        let key = hmacKey(hmac)
+    func addTestData(_ data: Data, forHMAC hmac: Data, personId: UUID) {
+        let key = storageKey(personId: personId, hmac: hmac)
         storage[key] = data
     }
 
-    private func hmacKey(_ hmac: Data) -> String {
+    // MARK: - Private Helpers
+
+    private func storageKey(personId: UUID, hmac: Data) -> String {
+        "\(personId.uuidString)/\(hmacHex(hmac))"
+    }
+
+    private func hmacHex(_ hmac: Data) -> String {
         hmac.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func dataFromHex(_ hex: String) -> Data? {
+        guard hex.count.isMultiple(of: 2) else { return nil }
+        var data = Data(capacity: hex.count / 2)
+        var index = hex.startIndex
+        while index < hex.endIndex {
+            let nextIndex = hex.index(index, offsetBy: 2)
+            guard let byte = UInt8(hex[index ..< nextIndex], radix: 16) else { return nil }
+            data.append(byte)
+            index = nextIndex
+        }
+        return data
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockDocumentFileStorageService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockDocumentFileStorageService.swift
@@ -12,7 +12,7 @@ final class MockDocumentFileStorageService: DocumentFileStorageServiceProtocol, 
         let personId: UUID
     }
 
-    struct HMACPersonCall: Equatable {
+    struct BlobLookup: Equatable {
         let contentHMAC: Data
         let personId: UUID
     }
@@ -31,11 +31,11 @@ final class MockDocumentFileStorageService: DocumentFileStorageServiceProtocol, 
     // MARK: - Call Tracking
 
     var storeCalls: [StoreCall] = []
-    var retrieveCalls: [HMACPersonCall] = []
-    var deleteCalls: [HMACPersonCall] = []
-    var existsCalls: [HMACPersonCall] = []
+    var retrieveCalls: [BlobLookup] = []
+    var deleteCalls: [BlobLookup] = []
+    var existsCalls: [BlobLookup] = []
     var listBlobsCalls: [UUID] = []
-    var blobSizeCalls: [HMACPersonCall] = []
+    var blobSizeCalls: [BlobLookup] = []
 
     // MARK: - DocumentFileStorageServiceProtocol
 
@@ -50,7 +50,7 @@ final class MockDocumentFileStorageService: DocumentFileStorageServiceProtocol, 
     }
 
     func retrieve(contentHMAC: Data, personId: UUID) throws -> Data {
-        retrieveCalls.append(HMACPersonCall(contentHMAC: contentHMAC, personId: personId))
+        retrieveCalls.append(BlobLookup(contentHMAC: contentHMAC, personId: personId))
         if shouldFailRetrieve {
             throw ModelError.documentContentCorrupted
         }
@@ -62,7 +62,7 @@ final class MockDocumentFileStorageService: DocumentFileStorageServiceProtocol, 
     }
 
     func delete(contentHMAC: Data, personId: UUID) throws {
-        deleteCalls.append(HMACPersonCall(contentHMAC: contentHMAC, personId: personId))
+        deleteCalls.append(BlobLookup(contentHMAC: contentHMAC, personId: personId))
         if shouldFailDelete {
             throw ModelError.documentStorageFailed(reason: "Mock delete failure")
         }
@@ -71,7 +71,7 @@ final class MockDocumentFileStorageService: DocumentFileStorageServiceProtocol, 
     }
 
     func exists(contentHMAC: Data, personId: UUID) -> Bool {
-        existsCalls.append(HMACPersonCall(contentHMAC: contentHMAC, personId: personId))
+        existsCalls.append(BlobLookup(contentHMAC: contentHMAC, personId: personId))
         let key = storageKey(personId: personId, hmac: contentHMAC)
         return storage[key] != nil
     }
@@ -93,7 +93,7 @@ final class MockDocumentFileStorageService: DocumentFileStorageServiceProtocol, 
     }
 
     func blobSize(contentHMAC: Data, personId: UUID) throws -> UInt64 {
-        blobSizeCalls.append(HMACPersonCall(contentHMAC: contentHMAC, personId: personId))
+        blobSizeCalls.append(BlobLookup(contentHMAC: contentHMAC, personId: personId))
         let key = storageKey(personId: personId, hmac: contentHMAC)
         guard let data = storage[key] else {
             throw ModelError.documentNotFound()

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockDocumentReferenceQueryService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockDocumentReferenceQueryService.swift
@@ -11,16 +11,19 @@ final class MockDocumentReferenceQueryService: DocumentReferenceQueryServiceProt
     var attachmentsForCalls: [UUID] = []
     var allDocumentsCalls: [UUID] = []
     var isHmacReferencedCalls: [(contentHMAC: Data, excludingRecordId: UUID)] = []
+    var allReferencedHMACsCalls: [UUID] = []
 
     // MARK: - Configurable Results
 
     var attachmentsResult: [PersistedDocumentReference] = []
     var allDocumentsResult: [PersistedDocumentReference] = []
     var isHmacReferencedResult = false
+    var allReferencedHMACsResult: Set<Data> = []
 
     var attachmentsError: Error?
     var allDocumentsError: Error?
     var isHmacReferencedError: Error?
+    var allReferencedHMACsError: Error?
 
     // MARK: - DocumentReferenceQueryServiceProtocol
 
@@ -58,5 +61,14 @@ final class MockDocumentReferenceQueryService: DocumentReferenceQueryServiceProt
             throw isHmacReferencedError
         }
         return isHmacReferencedResult
+    }
+
+    func allReferencedHMACs(
+        personId: UUID,
+        primaryKey: SymmetricKey
+    ) async throws -> Set<Data> {
+        allReferencedHMACsCalls.append(personId)
+        if let allReferencedHMACsError { throw allReferencedHMACsError }
+        return allReferencedHMACsResult
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockOrphanBlobCleanupService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockOrphanBlobCleanupService.swift
@@ -20,6 +20,19 @@ final class MockOrphanBlobCleanupService: OrphanBlobCleanupServiceProtocol, @unc
     var cleanOrphansError: Error?
     var countOrphansError: Error?
 
+    // MARK: - Test Helpers
+
+    /// Resets all call records and stubs to their default values. Use between test cases
+    /// that share a single mock instance.
+    func reset() {
+        cleanOrphansCalls.removeAll()
+        countOrphansCalls.removeAll()
+        cleanOrphansResult = CleanupResult(orphanCount: 0, freedBytes: 0)
+        countOrphansResult = CleanupResult(orphanCount: 0, freedBytes: 0)
+        cleanOrphansError = nil
+        countOrphansError = nil
+    }
+
     // MARK: - OrphanBlobCleanupServiceProtocol
 
     func cleanOrphans(personId: UUID, primaryKey _: SymmetricKey) async throws -> CleanupResult {

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockOrphanBlobCleanupService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockOrphanBlobCleanupService.swift
@@ -1,0 +1,40 @@
+import CryptoKit
+import Foundation
+@testable import FamilyMedicalApp
+
+/// Test mock for OrphanBlobCleanupServiceProtocol.
+///
+/// Records calls and returns pre-configured `CleanupResult`s or throws pre-configured
+/// errors. Used by Task 6's Settings UI wiring (dry-run + confirmation dialog) and any
+/// future launch-time cleanup wiring in Task 7.
+final class MockOrphanBlobCleanupService: OrphanBlobCleanupServiceProtocol, @unchecked Sendable {
+    // MARK: - Call Tracking
+
+    var cleanOrphansCalls: [UUID] = []
+    var countOrphansCalls: [UUID] = []
+
+    // MARK: - Result / Error Stubs
+
+    var cleanOrphansResult = CleanupResult(orphanCount: 0, freedBytes: 0)
+    var countOrphansResult = CleanupResult(orphanCount: 0, freedBytes: 0)
+    var cleanOrphansError: Error?
+    var countOrphansError: Error?
+
+    // MARK: - OrphanBlobCleanupServiceProtocol
+
+    func cleanOrphans(personId: UUID, primaryKey _: SymmetricKey) async throws -> CleanupResult {
+        cleanOrphansCalls.append(personId)
+        if let cleanOrphansError {
+            throw cleanOrphansError
+        }
+        return cleanOrphansResult
+    }
+
+    func countOrphans(personId: UUID, primaryKey _: SymmetricKey) async throws -> CleanupResult {
+        countOrphansCalls.append(personId)
+        if let countOrphansError {
+            throw countOrphansError
+        }
+        return countOrphansResult
+    }
+}

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Attachment/DocumentBlobServiceTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Attachment/DocumentBlobServiceTests.swift
@@ -238,7 +238,7 @@ struct DocumentBlobServiceTests {
         )
         #expect(ctx.encryption.decryptCalls.count == 1)
         #expect(ctx.fileStorage.retrieveCalls.count == 1)
-        #expect(ctx.fileStorage.retrieveCalls.first == stored.contentHMAC)
+        #expect(ctx.fileStorage.retrieveCalls.first?.contentHMAC == stored.contentHMAC)
         // Original bytes are stored unchanged, so round-trip equals the original.
         #expect(decrypted == original)
     }
@@ -259,7 +259,7 @@ struct DocumentBlobServiceTests {
     func retrieveCorruptedBlob() async throws {
         let ctx = Self.makeFixture()
         // Seed storage with arbitrary "encrypted" bytes the mock encryption does not know
-        ctx.fileStorage.addTestData(Data([0x01, 0x02, 0x03]), forHMAC: Data([0xBE, 0xEF]))
+        ctx.fileStorage.addTestData(Data([0x01, 0x02, 0x03]), forHMAC: Data([0xBE, 0xEF]), personId: ctx.personId)
         await #expect(throws: ModelError.self) {
             _ = try await ctx.service.retrieve(
                 contentHMAC: Data([0xBE, 0xEF]),
@@ -279,7 +279,7 @@ struct DocumentBlobServiceTests {
             isReferencedElsewhere: false
         )
         #expect(ctx.fileStorage.deleteCalls.count == 1)
-        #expect(ctx.fileStorage.deleteCalls.first == Data([0xAB, 0xCD]))
+        #expect(ctx.fileStorage.deleteCalls.first?.contentHMAC == Data([0xAB, 0xCD]))
     }
 
     @Test("deleteIfUnreferenced keeps blob when other records reference it")

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Attachment/DocumentBlobServiceTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Attachment/DocumentBlobServiceTests.swift
@@ -207,6 +207,46 @@ struct DocumentBlobServiceTests {
         #expect(first.contentHMAC == ctx.fileStorage.storeCalls.first?.contentHMAC)
     }
 
+    @Test("store marks the blob as in-flight atomically with the disk write")
+    func storeMarksBlobAsInFlightAtomically() async throws {
+        let ctx = Self.makeFixture()
+        let stored = try await ctx.service.store(
+            plaintext: Self.makeJPEG(),
+            personId: ctx.personId,
+            primaryKey: ctx.primaryKey
+        )
+        // Immediately after `store` returns, the HMAC MUST already be in-flight.
+        // This pins the race-closing contract: no interleaving window exists where
+        // an orphan scan could observe the on-disk blob without also observing the
+        // in-flight bit, because both mutations are serialized on the same actor.
+        let inFlight = await ctx.service.isInFlight(contentHMAC: stored.contentHMAC)
+        #expect(inFlight)
+    }
+
+    @Test("store marks HMAC in-flight even when the blob already exists (dedup path)")
+    func storeMarksInFlightOnDedup() async throws {
+        let ctx = Self.makeFixture()
+        let first = try await ctx.service.store(
+            plaintext: Self.makePDF(),
+            personId: ctx.personId,
+            primaryKey: ctx.primaryKey
+        )
+        // Clear the in-flight flag so we can observe the second store re-marking it.
+        await ctx.service.clearInFlight(contentHMAC: first.contentHMAC)
+        #expect(await !ctx.service.isInFlight(contentHMAC: first.contentHMAC))
+
+        // Second store of identical bytes hits the dedup branch (no new disk write).
+        let second = try await ctx.service.store(
+            plaintext: Self.makePDF(),
+            personId: ctx.personId,
+            primaryKey: ctx.primaryKey
+        )
+        #expect(first.contentHMAC == second.contentHMAC)
+        // Even on the dedup path, the HMAC must be re-marked in-flight so an
+        // in-progress second save can't be reaped before its own record lands.
+        #expect(await ctx.service.isInFlight(contentHMAC: second.contentHMAC))
+    }
+
     @Test("store validates image via CGImageSource and reports the detected MIME")
     func storeValidatesImageViaCGImageSource() async throws {
         let ctx = Self.makeFixture()

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Attachment/DocumentBlobServiceTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Attachment/DocumentBlobServiceTests.swift
@@ -8,7 +8,7 @@ import UIKit
 struct DocumentBlobServiceTests {
     // MARK: - Fixtures
 
-    private struct Fixture {
+    struct Fixture {
         let service: DocumentBlobService
         let fileStorage: MockDocumentFileStorageService
         let imageProcessor: MockImageProcessingService
@@ -18,7 +18,7 @@ struct DocumentBlobServiceTests {
         let primaryKey: SymmetricKey
     }
 
-    private static func makeFixture() -> Fixture {
+    static func makeFixture() -> Fixture {
         let fileStorage = MockDocumentFileStorageService()
         let imageProcessor = MockImageProcessingService()
         let encryption = MockEncryptionService()
@@ -297,5 +297,97 @@ struct DocumentBlobServiceTests {
             isReferencedElsewhere: true
         )
         #expect(ctx.fileStorage.deleteCalls.isEmpty)
+    }
+}
+
+// MARK: - In-Flight Tracking
+
+@Suite("DocumentBlobService In-Flight Tracking")
+private struct DocumentBlobServiceInFlightTests {
+    @Test("markInFlight registers HMAC, clearInFlight unregisters it, isInFlight reflects state")
+    func inFlightRoundTrip() async {
+        let ctx = DocumentBlobServiceTests.makeFixture()
+        let hmac = Data([0x01, 0x02, 0x03])
+
+        let beforeMark = await ctx.service.isInFlight(contentHMAC: hmac)
+        #expect(!beforeMark)
+
+        await ctx.service.markInFlight(contentHMAC: hmac)
+        let afterMark = await ctx.service.isInFlight(contentHMAC: hmac)
+        #expect(afterMark)
+
+        await ctx.service.clearInFlight(contentHMAC: hmac)
+        let afterClear = await ctx.service.isInFlight(contentHMAC: hmac)
+        #expect(!afterClear)
+    }
+
+    @Test("inFlight state is per-HMAC and independent")
+    func inFlightMultipleHMACs() async {
+        let ctx = DocumentBlobServiceTests.makeFixture()
+        let hmacAlpha = Data([0x01])
+        let hmacBeta = Data([0x02])
+
+        await ctx.service.markInFlight(contentHMAC: hmacAlpha)
+        await ctx.service.markInFlight(contentHMAC: hmacBeta)
+        #expect(await ctx.service.isInFlight(contentHMAC: hmacAlpha))
+        #expect(await ctx.service.isInFlight(contentHMAC: hmacBeta))
+
+        await ctx.service.clearInFlight(contentHMAC: hmacAlpha)
+        #expect(await !(ctx.service.isInFlight(contentHMAC: hmacAlpha)))
+        #expect(await ctx.service.isInFlight(contentHMAC: hmacBeta))
+    }
+}
+
+// MARK: - Cleanup Pass-Throughs
+
+@Suite("DocumentBlobService Cleanup Pass-Throughs")
+private struct DocumentBlobServiceCleanupTests {
+    @Test("listBlobs delegates to file storage")
+    func listBlobsDelegates() async throws {
+        let ctx = DocumentBlobServiceTests.makeFixture()
+        let hmac1 = Data([0x01])
+        let hmac2 = Data([0x02])
+        ctx.fileStorage.addTestData(Data("a".utf8), forHMAC: hmac1, personId: ctx.personId)
+        ctx.fileStorage.addTestData(Data("b".utf8), forHMAC: hmac2, personId: ctx.personId)
+
+        let blobs = try await ctx.service.listBlobs(personId: ctx.personId)
+        #expect(blobs == [hmac1, hmac2])
+        #expect(ctx.fileStorage.listBlobsCalls == [ctx.personId])
+    }
+
+    @Test("blobSize delegates to file storage")
+    func blobSizeDelegates() async throws {
+        let ctx = DocumentBlobServiceTests.makeFixture()
+        let hmac = Data([0x01])
+        let data = Data(repeating: 0, count: 42)
+        ctx.fileStorage.addTestData(data, forHMAC: hmac, personId: ctx.personId)
+
+        let size = try await ctx.service.blobSize(contentHMAC: hmac, personId: ctx.personId)
+        #expect(size == 42)
+        #expect(ctx.fileStorage.blobSizeCalls.count == 1)
+    }
+
+    @Test("deleteDirect removes the blob unconditionally")
+    func deleteDirectRemovesBlob() async throws {
+        let ctx = DocumentBlobServiceTests.makeFixture()
+        let hmac = Data([0x01])
+        ctx.fileStorage.addTestData(Data("x".utf8), forHMAC: hmac, personId: ctx.personId)
+
+        try await ctx.service.deleteDirect(contentHMAC: hmac, personId: ctx.personId)
+
+        #expect(!ctx.fileStorage.exists(contentHMAC: hmac, personId: ctx.personId))
+        #expect(ctx.fileStorage.deleteCalls.count == 1)
+    }
+
+    @Test("deleteDirect surfaces file storage errors")
+    func deleteDirectSurfacesErrors() async throws {
+        let ctx = DocumentBlobServiceTests.makeFixture()
+        ctx.fileStorage.shouldFailDelete = true
+        await #expect(throws: ModelError.self) {
+            try await ctx.service.deleteDirect(
+                contentHMAC: Data([0xAA]),
+                personId: ctx.personId
+            )
+        }
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Attachment/DocumentBlobServiceTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Attachment/DocumentBlobServiceTests.swift
@@ -336,6 +336,53 @@ private struct DocumentBlobServiceInFlightTests {
         #expect(await !(ctx.service.isInFlight(contentHMAC: hmacAlpha)))
         #expect(await ctx.service.isInFlight(contentHMAC: hmacBeta))
     }
+
+    @Test("markInFlight on an already-in-flight HMAC is idempotent")
+    func inFlightReMarkIsIdempotent() async {
+        let ctx = DocumentBlobServiceTests.makeFixture()
+        let hmac = Data([0x42])
+
+        await ctx.service.markInFlight(contentHMAC: hmac)
+        await ctx.service.markInFlight(contentHMAC: hmac)
+        let present = await ctx.service.isInFlight(contentHMAC: hmac)
+        #expect(present)
+
+        await ctx.service.clearInFlight(contentHMAC: hmac)
+        let absent = await ctx.service.isInFlight(contentHMAC: hmac)
+        #expect(!absent)
+    }
+
+    @Test("In-flight set is race-safe under concurrent mark/query")
+    func inFlightConcurrentStress() async {
+        let ctx = DocumentBlobServiceTests.makeFixture()
+        let hmacs = (0 ..< 50).map { Data([UInt8($0)]) }
+
+        await withTaskGroup(of: Void.self) { group in
+            for hmac in hmacs {
+                group.addTask {
+                    await ctx.service.markInFlight(contentHMAC: hmac)
+                }
+            }
+        }
+
+        for hmac in hmacs {
+            let present = await ctx.service.isInFlight(contentHMAC: hmac)
+            #expect(present, "HMAC should be in flight after concurrent marks")
+        }
+
+        await withTaskGroup(of: Void.self) { group in
+            for hmac in hmacs {
+                group.addTask {
+                    await ctx.service.clearInFlight(contentHMAC: hmac)
+                }
+            }
+        }
+
+        for hmac in hmacs {
+            let present = await ctx.service.isInFlight(contentHMAC: hmac)
+            #expect(!present, "HMAC should be cleared after concurrent clears")
+        }
+    }
 }
 
 // MARK: - Cleanup Pass-Throughs
@@ -365,6 +412,8 @@ private struct DocumentBlobServiceCleanupTests {
         let size = try await ctx.service.blobSize(contentHMAC: hmac, personId: ctx.personId)
         #expect(size == 42)
         #expect(ctx.fileStorage.blobSizeCalls.count == 1)
+        #expect(ctx.fileStorage.blobSizeCalls.first?.contentHMAC == hmac)
+        #expect(ctx.fileStorage.blobSizeCalls.first?.personId == ctx.personId)
     }
 
     @Test("deleteDirect removes the blob unconditionally")

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Attachment/DocumentBlobServiceTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Attachment/DocumentBlobServiceTests.swift
@@ -276,10 +276,16 @@ struct DocumentBlobServiceTests {
         let ctx = Self.makeFixture()
         try await ctx.service.deleteIfUnreferenced(
             contentHMAC: Data([0xAB, 0xCD]),
+            personId: ctx.personId,
             isReferencedElsewhere: false
         )
         #expect(ctx.fileStorage.deleteCalls.count == 1)
-        #expect(ctx.fileStorage.deleteCalls.first?.contentHMAC == Data([0xAB, 0xCD]))
+        let call = try #require(ctx.fileStorage.deleteCalls.first)
+        #expect(call.contentHMAC == Data([0xAB, 0xCD]))
+        // personId must be threaded through to the file-storage layer; the service
+        // must never fall back to a random UUID (which would silently miss the
+        // real per-person subdirectory and orphan the blob).
+        #expect(call.personId == ctx.personId)
     }
 
     @Test("deleteIfUnreferenced keeps blob when other records reference it")
@@ -287,6 +293,7 @@ struct DocumentBlobServiceTests {
         let ctx = Self.makeFixture()
         try await ctx.service.deleteIfUnreferenced(
             contentHMAC: Data([0xAB, 0xCD]),
+            personId: ctx.personId,
             isReferencedElsewhere: true
         )
         #expect(ctx.fileStorage.deleteCalls.isEmpty)

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Attachment/DocumentFileStorageServiceTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Attachment/DocumentFileStorageServiceTests.swift
@@ -2,14 +2,13 @@ import Foundation
 import Testing
 @testable import FamilyMedicalApp
 
-struct DocumentFileStorageServiceTests {
-    // MARK: - Test Fixtures
+// MARK: - Fixtures & Helpers
 
+struct DocumentFileStorageServiceTests {
     func makeService() throws -> (service: DocumentFileStorageService, tempDir: URL) {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        // Inject mock logger to avoid LoggingService.shared singleton timing dependencies
         let service = DocumentFileStorageService(
             attachmentsDirectory: tempDir,
             logger: MockCategoryLogger(category: .storage)
@@ -28,19 +27,19 @@ struct DocumentFileStorageServiceTests {
     func makeTestData(size: Int = 1_024) -> Data {
         Data((0 ..< size).map { _ in UInt8.random(in: 0 ... 255) })
     }
+}
 
-    // MARK: - Store Tests
+// MARK: - Store Tests
 
+extension DocumentFileStorageServiceTests {
     @Test
     func store_validData_returnsURL() throws {
         let (service, tempDir) = try makeService()
         defer { cleanupTempDir(tempDir) }
-
         let data = makeTestData()
         let hmac = makeTestHMAC()
-
-        let url = try service.store(encryptedData: data, contentHMAC: hmac)
-
+        let personId = UUID()
+        let url = try service.store(encryptedData: data, contentHMAC: hmac, personId: personId)
         #expect(url.pathExtension == "enc")
         #expect(FileManager.default.fileExists(atPath: url.path))
     }
@@ -49,13 +48,11 @@ struct DocumentFileStorageServiceTests {
     func store_validData_writesCorrectContent() throws {
         let (service, tempDir) = try makeService()
         defer { cleanupTempDir(tempDir) }
-
         let data = makeTestData()
         let hmac = makeTestHMAC()
-
-        let url = try service.store(encryptedData: data, contentHMAC: hmac)
+        let personId = UUID()
+        let url = try service.store(encryptedData: data, contentHMAC: hmac, personId: personId)
         let storedData = try Data(contentsOf: url)
-
         #expect(storedData == data)
     }
 
@@ -63,18 +60,13 @@ struct DocumentFileStorageServiceTests {
     func store_duplicateHMAC_doesNotOverwrite() throws {
         let (service, tempDir) = try makeService()
         defer { cleanupTempDir(tempDir) }
-
         let data1 = makeTestData()
         let data2 = makeTestData()
         let hmac = makeTestHMAC()
-
-        let url1 = try service.store(encryptedData: data1, contentHMAC: hmac)
-        let url2 = try service.store(encryptedData: data2, contentHMAC: hmac)
-
-        // Same URL returned
+        let personId = UUID()
+        let url1 = try service.store(encryptedData: data1, contentHMAC: hmac, personId: personId)
+        let url2 = try service.store(encryptedData: data2, contentHMAC: hmac, personId: personId)
         #expect(url1 == url2)
-
-        // Original data preserved
         let storedData = try Data(contentsOf: url1)
         #expect(storedData == data1)
     }
@@ -83,37 +75,73 @@ struct DocumentFileStorageServiceTests {
     func store_differentHMACs_storesSeparateFiles() throws {
         let (service, tempDir) = try makeService()
         defer { cleanupTempDir(tempDir) }
-
         let data1 = makeTestData()
         let data2 = makeTestData()
         let hmac1 = makeTestHMAC()
         let hmac2 = makeTestHMAC()
-
-        let url1 = try service.store(encryptedData: data1, contentHMAC: hmac1)
-        let url2 = try service.store(encryptedData: data2, contentHMAC: hmac2)
-
+        let personId = UUID()
+        let url1 = try service.store(encryptedData: data1, contentHMAC: hmac1, personId: personId)
+        let url2 = try service.store(encryptedData: data2, contentHMAC: hmac2, personId: personId)
         #expect(url1 != url2)
-
         let stored1 = try Data(contentsOf: url1)
         let stored2 = try Data(contentsOf: url2)
-
         #expect(stored1 == data1)
         #expect(stored2 == data2)
     }
 
-    // MARK: - Retrieve Tests
+    @Test
+    func store_differentPersonIds_storeInSeparateSubdirectories() throws {
+        let (service, tempDir) = try makeService()
+        defer { cleanupTempDir(tempDir) }
+        let data = makeTestData()
+        let hmac = makeTestHMAC()
+        let personId1 = UUID()
+        let personId2 = UUID()
+        let url1 = try service.store(encryptedData: data, contentHMAC: hmac, personId: personId1)
+        let url2 = try service.store(encryptedData: data, contentHMAC: hmac, personId: personId2)
+        #expect(url1 != url2)
+        #expect(url1.path.contains(personId1.uuidString))
+        #expect(url2.path.contains(personId2.uuidString))
+    }
 
+    @Test
+    func store_generatesHexFilename() throws {
+        let (service, tempDir) = try makeService()
+        defer { cleanupTempDir(tempDir) }
+        let data = makeTestData()
+        let hmac = Data([0x01, 0x02, 0xAB, 0xCD])
+        let personId = UUID()
+        let url = try service.store(encryptedData: data, contentHMAC: hmac, personId: personId)
+        #expect(url.lastPathComponent == "0102abcd.enc")
+        #expect(url.path.contains(personId.uuidString))
+    }
+
+    @Test
+    func store_emptyData_succeeds() throws {
+        let (service, tempDir) = try makeService()
+        defer { cleanupTempDir(tempDir) }
+        let emptyData = Data()
+        let hmac = makeTestHMAC()
+        let personId = UUID()
+        let url = try service.store(encryptedData: emptyData, contentHMAC: hmac, personId: personId)
+        let retrieved = try service.retrieve(contentHMAC: hmac, personId: personId)
+        #expect(FileManager.default.fileExists(atPath: url.path))
+        #expect(retrieved.isEmpty)
+    }
+}
+
+// MARK: - Retrieve Tests
+
+extension DocumentFileStorageServiceTests {
     @Test
     func retrieve_existingContent_returnsData() throws {
         let (service, tempDir) = try makeService()
         defer { cleanupTempDir(tempDir) }
-
         let data = makeTestData()
         let hmac = makeTestHMAC()
-
-        _ = try service.store(encryptedData: data, contentHMAC: hmac)
-        let retrieved = try service.retrieve(contentHMAC: hmac)
-
+        let personId = UUID()
+        _ = try service.store(encryptedData: data, contentHMAC: hmac, personId: personId)
+        let retrieved = try service.retrieve(contentHMAC: hmac, personId: personId)
         #expect(retrieved == data)
     }
 
@@ -121,29 +149,27 @@ struct DocumentFileStorageServiceTests {
     func retrieve_nonExistent_throwsNotFound() throws {
         let (service, tempDir) = try makeService()
         defer { cleanupTempDir(tempDir) }
-
         let hmac = makeTestHMAC()
-
+        let personId = UUID()
         #expect(throws: ModelError.self) {
-            _ = try service.retrieve(contentHMAC: hmac)
+            _ = try service.retrieve(contentHMAC: hmac, personId: personId)
         }
     }
+}
 
-    // MARK: - Delete Tests
+// MARK: - Delete Tests
 
+extension DocumentFileStorageServiceTests {
     @Test
     func delete_existingContent_removesFile() throws {
         let (service, tempDir) = try makeService()
         defer { cleanupTempDir(tempDir) }
-
         let data = makeTestData()
         let hmac = makeTestHMAC()
-
-        let url = try service.store(encryptedData: data, contentHMAC: hmac)
+        let personId = UUID()
+        let url = try service.store(encryptedData: data, contentHMAC: hmac, personId: personId)
         #expect(FileManager.default.fileExists(atPath: url.path))
-
-        try service.delete(contentHMAC: hmac)
-
+        try service.delete(contentHMAC: hmac, personId: personId)
         #expect(!FileManager.default.fileExists(atPath: url.path))
     }
 
@@ -151,123 +177,176 @@ struct DocumentFileStorageServiceTests {
     func delete_nonExistent_doesNotThrow() throws {
         let (service, tempDir) = try makeService()
         defer { cleanupTempDir(tempDir) }
-
         let hmac = makeTestHMAC()
-
-        // Should not throw (idempotent)
-        try service.delete(contentHMAC: hmac)
+        let personId = UUID()
+        try service.delete(contentHMAC: hmac, personId: personId)
     }
+}
 
-    // MARK: - Exists Tests
+// MARK: - Exists Tests
 
+extension DocumentFileStorageServiceTests {
     @Test
     func exists_existingContent_returnsTrue() throws {
         let (service, tempDir) = try makeService()
         defer { cleanupTempDir(tempDir) }
-
         let data = makeTestData()
         let hmac = makeTestHMAC()
-
-        _ = try service.store(encryptedData: data, contentHMAC: hmac)
-
-        #expect(service.exists(contentHMAC: hmac))
+        let personId = UUID()
+        _ = try service.store(encryptedData: data, contentHMAC: hmac, personId: personId)
+        #expect(service.exists(contentHMAC: hmac, personId: personId))
     }
 
     @Test
     func exists_nonExistent_returnsFalse() throws {
         let (service, tempDir) = try makeService()
         defer { cleanupTempDir(tempDir) }
-
         let hmac = makeTestHMAC()
-
-        #expect(!service.exists(contentHMAC: hmac))
+        let personId = UUID()
+        #expect(!service.exists(contentHMAC: hmac, personId: personId))
     }
 
     @Test
     func exists_afterDelete_returnsFalse() throws {
         let (service, tempDir) = try makeService()
         defer { cleanupTempDir(tempDir) }
-
         let data = makeTestData()
         let hmac = makeTestHMAC()
-
-        _ = try service.store(encryptedData: data, contentHMAC: hmac)
-        #expect(service.exists(contentHMAC: hmac))
-
-        try service.delete(contentHMAC: hmac)
-        #expect(!service.exists(contentHMAC: hmac))
+        let personId = UUID()
+        _ = try service.store(encryptedData: data, contentHMAC: hmac, personId: personId)
+        #expect(service.exists(contentHMAC: hmac, personId: personId))
+        try service.delete(contentHMAC: hmac, personId: personId)
+        #expect(!service.exists(contentHMAC: hmac, personId: personId))
     }
+}
 
-    // MARK: - File Naming Tests
+// MARK: - listBlobs Tests
 
+extension DocumentFileStorageServiceTests {
     @Test
-    func store_generatesHexFilename() throws {
+    func listBlobs_noDirectory_returnsEmpty() throws {
         let (service, tempDir) = try makeService()
         defer { cleanupTempDir(tempDir) }
-
-        let data = makeTestData()
-        // Known HMAC for predictable filename
-        let hmac = Data([0x01, 0x02, 0xAB, 0xCD])
-
-        let url = try service.store(encryptedData: data, contentHMAC: hmac)
-
-        let expectedName = "0102abcd.enc"
-        #expect(url.lastPathComponent == expectedName)
+        let blobs = try service.listBlobs(personId: UUID())
+        #expect(blobs.isEmpty)
     }
 
-    // MARK: - Large File Tests
+    @Test
+    func listBlobs_afterStore_returnsStoredHMAC() throws {
+        let (service, tempDir) = try makeService()
+        defer { cleanupTempDir(tempDir) }
+        let data = makeTestData()
+        let hmac = makeTestHMAC()
+        let personId = UUID()
+        _ = try service.store(encryptedData: data, contentHMAC: hmac, personId: personId)
+        let blobs = try service.listBlobs(personId: personId)
+        #expect(blobs.count == 1)
+        #expect(blobs.contains(hmac))
+    }
 
+    @Test
+    func listBlobs_afterDelete_excludesDeletedHMAC() throws {
+        let (service, tempDir) = try makeService()
+        defer { cleanupTempDir(tempDir) }
+        let data = makeTestData()
+        let hmac = makeTestHMAC()
+        let personId = UUID()
+        _ = try service.store(encryptedData: data, contentHMAC: hmac, personId: personId)
+        try service.delete(contentHMAC: hmac, personId: personId)
+        let blobs = try service.listBlobs(personId: personId)
+        #expect(!blobs.contains(hmac))
+    }
+
+    @Test
+    func listBlobs_onlyReturnsHMACsForRequestedPerson() throws {
+        let (service, tempDir) = try makeService()
+        defer { cleanupTempDir(tempDir) }
+        let data = makeTestData()
+        let hmac1 = makeTestHMAC()
+        let hmac2 = makeTestHMAC()
+        let personId1 = UUID()
+        let personId2 = UUID()
+        _ = try service.store(encryptedData: data, contentHMAC: hmac1, personId: personId1)
+        _ = try service.store(encryptedData: data, contentHMAC: hmac2, personId: personId2)
+        let blobs1 = try service.listBlobs(personId: personId1)
+        let blobs2 = try service.listBlobs(personId: personId2)
+        #expect(blobs1.contains(hmac1))
+        #expect(!blobs1.contains(hmac2))
+        #expect(blobs2.contains(hmac2))
+        #expect(!blobs2.contains(hmac1))
+    }
+}
+
+// MARK: - blobSize Tests
+
+extension DocumentFileStorageServiceTests {
+    @Test
+    func blobSize_returnsCorrectSize() throws {
+        let (service, tempDir) = try makeService()
+        defer { cleanupTempDir(tempDir) }
+        let data = makeTestData(size: 512)
+        let hmac = makeTestHMAC()
+        let personId = UUID()
+        _ = try service.store(encryptedData: data, contentHMAC: hmac, personId: personId)
+        let size = try service.blobSize(contentHMAC: hmac, personId: personId)
+        #expect(size == UInt64(data.count))
+    }
+
+    @Test
+    func blobSize_nonExistent_throws() throws {
+        let (service, tempDir) = try makeService()
+        defer { cleanupTempDir(tempDir) }
+        let hmac = makeTestHMAC()
+        let personId = UUID()
+        #expect(throws: ModelError.self) {
+            _ = try service.blobSize(contentHMAC: hmac, personId: personId)
+        }
+    }
+}
+
+// MARK: - Large File & Round-Trip Tests
+
+extension DocumentFileStorageServiceTests {
     @Test
     func store_largeData_succeeds() throws {
         let (service, tempDir) = try makeService()
         defer { cleanupTempDir(tempDir) }
-
-        // 1 MB of data
         let data = makeTestData(size: 1_000_000)
         let hmac = makeTestHMAC()
-
-        let url = try service.store(encryptedData: data, contentHMAC: hmac)
-        let retrieved = try service.retrieve(contentHMAC: hmac)
-
+        let personId = UUID()
+        let url = try service.store(encryptedData: data, contentHMAC: hmac, personId: personId)
+        let retrieved = try service.retrieve(contentHMAC: hmac, personId: personId)
         #expect(FileManager.default.fileExists(atPath: url.path))
         #expect(retrieved.count == data.count)
         #expect(retrieved == data)
     }
 
-    // MARK: - Round-Trip Tests
-
     @Test
     func storeRetrieve_roundTrip_preservesData() throws {
         let (service, tempDir) = try makeService()
         defer { cleanupTempDir(tempDir) }
-
         let originalData = Data("Test attachment content with special chars: 日本語 🎉".utf8)
         let hmac = makeTestHMAC()
-
-        _ = try service.store(encryptedData: originalData, contentHMAC: hmac)
-        let retrieved = try service.retrieve(contentHMAC: hmac)
-
+        let personId = UUID()
+        _ = try service.store(encryptedData: originalData, contentHMAC: hmac, personId: personId)
+        let retrieved = try service.retrieve(contentHMAC: hmac, personId: personId)
         #expect(retrieved == originalData)
     }
+}
 
-    // MARK: - Default Init Tests
+// MARK: - Default Init Tests
 
+extension DocumentFileStorageServiceTests {
     @Test
     func init_default_createsService() throws {
-        // This tests the default init that creates the Application Support/Attachments directory
         let service = try DocumentFileStorageService()
-
-        // Verify service is functional by storing and retrieving
         let data = makeTestData()
         let hmac = makeTestHMAC()
-
-        let url = try service.store(encryptedData: data, contentHMAC: hmac)
-        let retrieved = try service.retrieve(contentHMAC: hmac)
-
+        let personId = UUID()
+        let url = try service.store(encryptedData: data, contentHMAC: hmac, personId: personId)
+        let retrieved = try service.retrieve(contentHMAC: hmac, personId: personId)
         #expect(retrieved == data)
-
-        // Clean up
-        try service.delete(contentHMAC: hmac)
+        try service.delete(contentHMAC: hmac, personId: personId)
         #expect(!FileManager.default.fileExists(atPath: url.path))
     }
 
@@ -276,39 +355,17 @@ struct DocumentFileStorageServiceTests {
         let service = try DocumentFileStorageService()
         let data = makeTestData()
         let hmac = makeTestHMAC()
-
-        let url = try service.store(encryptedData: data, contentHMAC: hmac)
-
-        // Verify the URL is in Application Support/Attachments
+        let personId = UUID()
+        let url = try service.store(encryptedData: data, contentHMAC: hmac, personId: personId)
         #expect(url.path.contains("Application Support"))
         #expect(url.path.contains("Attachments"))
-
-        // Clean up
-        try service.delete(contentHMAC: hmac)
+        #expect(url.path.contains(personId.uuidString))
+        try service.delete(contentHMAC: hmac, personId: personId)
     }
 
     @Test
     func init_default_createsDirectoryIfNotExists() throws {
-        // This tests that createAttachmentsDirectory is called and works
-        // The directory might already exist, so this just ensures no error
         let service = try DocumentFileStorageService()
-        #expect(service.exists(contentHMAC: makeTestHMAC()) == false)
-    }
-
-    // MARK: - Error Handling Tests
-
-    @Test
-    func store_emptyData_succeeds() throws {
-        let (service, tempDir) = try makeService()
-        defer { cleanupTempDir(tempDir) }
-
-        let emptyData = Data()
-        let hmac = makeTestHMAC()
-
-        let url = try service.store(encryptedData: emptyData, contentHMAC: hmac)
-        let retrieved = try service.retrieve(contentHMAC: hmac)
-
-        #expect(FileManager.default.fileExists(atPath: url.path))
-        #expect(retrieved.isEmpty)
+        #expect(service.exists(contentHMAC: makeTestHMAC(), personId: UUID()) == false)
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Attachment/DocumentFileStorageServiceTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Attachment/DocumentFileStorageServiceTests.swift
@@ -275,6 +275,51 @@ extension DocumentFileStorageServiceTests {
         #expect(blobs2.contains(hmac2))
         #expect(!blobs2.contains(hmac1))
     }
+
+    @Test
+    func listBlobs_ignoresMalformedFilenames_returnsValidOnly() throws {
+        let (service, tempDir) = try makeService()
+        defer { cleanupTempDir(tempDir) }
+        let personId = UUID()
+        let goodHmac = Data([0xDE, 0xAD, 0xBE, 0xEF])
+        // Store one well-formed blob so the person directory exists and contains a known entry.
+        _ = try service.store(encryptedData: makeTestData(), contentHMAC: goodHmac, personId: personId)
+
+        // Drop malformed `.enc` files directly into the person directory:
+        // - `not-hex.enc`: contains characters outside the [0-9a-f] alphabet
+        // - `abcg.enc`: contains an invalid hex character ('g')
+        // - `abc.enc`: odd-length hex stem
+        let personDir = tempDir.appendingPathComponent(personId.uuidString, isDirectory: true)
+        try Data().write(to: personDir.appendingPathComponent("not-hex.enc"))
+        try Data().write(to: personDir.appendingPathComponent("abcg.enc"))
+        try Data().write(to: personDir.appendingPathComponent("abc.enc"))
+        // Also an empty stem: `.enc` (produced by e.g. a stray creation) must not yield an empty-HMAC set member.
+        try Data().write(to: personDir.appendingPathComponent(".enc"))
+
+        let blobs = try service.listBlobs(personId: personId)
+        // Silently excluded, no throw; only the valid blob is returned.
+        #expect(blobs == [goodHmac])
+        #expect(!blobs.contains(Data()))
+    }
+
+    @Test
+    func listBlobs_ignoresNonEncFiles_returnsValidOnly() throws {
+        let (service, tempDir) = try makeService()
+        defer { cleanupTempDir(tempDir) }
+        let personId = UUID()
+        let goodHmac = Data([0x01, 0x23, 0x45, 0x67])
+        _ = try service.store(encryptedData: makeTestData(), contentHMAC: goodHmac, personId: personId)
+
+        let personDir = tempDir.appendingPathComponent(personId.uuidString, isDirectory: true)
+        // A typical macOS metadata file and a stray text file should both be ignored.
+        try Data().write(to: personDir.appendingPathComponent(".DS_Store"))
+        try Data("junk".utf8).write(to: personDir.appendingPathComponent("junk.txt"))
+        // Also an `.enc` file whose name is actually a different extension hidden inside.
+        try Data().write(to: personDir.appendingPathComponent("notes.md"))
+
+        let blobs = try service.listBlobs(personId: personId)
+        #expect(blobs == [goodHmac])
+    }
 }
 
 // MARK: - blobSize Tests

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Attachment/DocumentFileStorageServiceTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Attachment/DocumentFileStorageServiceTests.swift
@@ -285,14 +285,22 @@ extension DocumentFileStorageServiceTests {
         // Store one well-formed blob so the person directory exists and contains a known entry.
         _ = try service.store(encryptedData: makeTestData(), contentHMAC: goodHmac, personId: personId)
 
-        // Drop malformed `.enc` files directly into the person directory:
-        // - `not-hex.enc`: contains characters outside the [0-9a-f] alphabet
-        // - `abcg.enc`: contains an invalid hex character ('g')
-        // - `abc.enc`: odd-length hex stem
+        // Drop malformed `.enc` files directly into the person directory. Two distinct
+        // rejection branches are exercised:
+        //
+        // Even-length guard (hex.count.isMultiple(of: 2) == false):
+        //   - `not-hex.enc`: 7-char stem — odd length, rejected before per-char check
+        //   - `abc.enc`: 3-char stem — odd length
+        //
+        // Per-character hex check (UInt8(_:radix:16) returns nil):
+        //   - `abcg.enc`: 4-char stem, even length, but 'g' is not a hex digit
+        //   - `zzzz.enc`: 4-char stem, even length, all chars non-hex — explicit
+        //                 even-length-but-invalid-hex case
         let personDir = tempDir.appendingPathComponent(personId.uuidString, isDirectory: true)
         try Data().write(to: personDir.appendingPathComponent("not-hex.enc"))
         try Data().write(to: personDir.appendingPathComponent("abcg.enc"))
         try Data().write(to: personDir.appendingPathComponent("abc.enc"))
+        try Data().write(to: personDir.appendingPathComponent("zzzz.enc"))
         // Also an empty stem: `.enc` (produced by e.g. a stray creation) must not yield an empty-HMAC set member.
         try Data().write(to: personDir.appendingPathComponent(".enc"))
 
@@ -311,10 +319,12 @@ extension DocumentFileStorageServiceTests {
         _ = try service.store(encryptedData: makeTestData(), contentHMAC: goodHmac, personId: personId)
 
         let personDir = tempDir.appendingPathComponent(personId.uuidString, isDirectory: true)
-        // A typical macOS metadata file and a stray text file should both be ignored.
-        try Data().write(to: personDir.appendingPathComponent(".DS_Store"))
+        // Non-hidden files with wrong extensions must be excluded by the `pathExtension == "enc"`
+        // guard. Using visible files here (not `.DS_Store`) ensures we exercise that filter
+        // rather than the OS-level `.skipsHiddenFiles` option that would reject `.DS_Store`
+        // before the extension check even runs.
+        try Data("{}".utf8).write(to: personDir.appendingPathComponent("manifest.json"))
         try Data("junk".utf8).write(to: personDir.appendingPathComponent("junk.txt"))
-        // Also an `.enc` file whose name is actually a different extension hidden inside.
         try Data().write(to: personDir.appendingPathComponent("notes.md"))
 
         let blobs = try service.listBlobs(personId: personId)
@@ -343,8 +353,14 @@ extension DocumentFileStorageServiceTests {
         defer { cleanupTempDir(tempDir) }
         let hmac = makeTestHMAC()
         let personId = UUID()
-        #expect(throws: ModelError.self) {
+        // Pin the error case: a missing blob must throw `.documentNotFound`, not
+        // `.documentStorageFailed`. A future regression that swaps the guard for a
+        // generic catch block will fail here.
+        #expect {
             _ = try service.blobSize(contentHMAC: hmac, personId: personId)
+        } throws: { error in
+            guard case ModelError.documentNotFound = error else { return false }
+            return true
         }
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Attachment/LaunchOrphanCleanupCoordinatorTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Attachment/LaunchOrphanCleanupCoordinatorTests.swift
@@ -1,0 +1,115 @@
+import CryptoKit
+import Foundation
+import Testing
+@testable import FamilyMedicalApp
+
+@Suite("LaunchOrphanCleanupCoordinator Tests")
+struct LaunchOrphanCleanupCoordinatorTests {
+    // MARK: - Fixture
+
+    private struct Fixture {
+        let coordinator: LaunchOrphanCleanupCoordinator
+        let cleanupService: MockOrphanBlobCleanupService
+        let personRepository: MockPersonRepository
+        let primaryKeyProvider: MockPrimaryKeyProvider
+    }
+
+    private static func makeFixture(primaryKey: SymmetricKey? = nil) -> Fixture {
+        let cleanupService = MockOrphanBlobCleanupService()
+        let personRepository = MockPersonRepository()
+        let key = primaryKey ?? SymmetricKey(size: .bits256)
+        let primaryKeyProvider = MockPrimaryKeyProvider(primaryKey: key)
+        let coordinator = LaunchOrphanCleanupCoordinator(
+            cleanupService: cleanupService,
+            personRepository: personRepository,
+            primaryKeyProvider: primaryKeyProvider
+        )
+        return Fixture(
+            coordinator: coordinator,
+            cleanupService: cleanupService,
+            personRepository: personRepository,
+            primaryKeyProvider: primaryKeyProvider
+        )
+    }
+
+    // MARK: - Plan's 3 Core Tests
+
+    @Test("runCleanup calls cleanOrphans for each accessible person")
+    func runCleanup_perPerson() async throws {
+        let fixture = Self.makeFixture()
+        // MockPersonRepository.fetchAll returns persons sorted alphabetically by name
+        let alice = try Person(name: "Alice")
+        let bob = try Person(name: "Bob")
+        fixture.personRepository.addPerson(alice)
+        fixture.personRepository.addPerson(bob)
+
+        await fixture.coordinator.runCleanup()
+
+        #expect(fixture.cleanupService.cleanOrphansCalls.count == 2)
+        // Alphabetical order: Alice then Bob
+        #expect(fixture.cleanupService.cleanOrphansCalls == [alice.id, bob.id])
+        #expect(fixture.personRepository.fetchAllCallCount == 1)
+    }
+
+    @Test("runCleanup is a no-op when primary key is unavailable")
+    func runCleanup_noPrimaryKey() async throws {
+        let fixture = Self.makeFixture()
+        fixture.primaryKeyProvider.shouldFail = true
+        try fixture.personRepository.addPerson(Person(name: "Alice"))
+
+        await fixture.coordinator.runCleanup()
+
+        #expect(fixture.cleanupService.cleanOrphansCalls.isEmpty)
+        // Must not even reach fetchAll when the key is unavailable
+        #expect(fixture.personRepository.fetchAllCallCount == 0)
+    }
+
+    @Test("runCleanup continues if one person's cleanup fails")
+    func runCleanup_perPersonResilience() async throws {
+        let fixture = Self.makeFixture()
+        try fixture.personRepository.addPerson(Person(name: "Alice"))
+        try fixture.personRepository.addPerson(Person(name: "Bob"))
+        fixture.cleanupService.cleanOrphansError = RepositoryError.saveFailed("mock failure")
+
+        await fixture.coordinator.runCleanup()
+
+        // Both persons still get attempted — sibling failures must not block the sweep
+        #expect(fixture.cleanupService.cleanOrphansCalls.count == 2)
+    }
+
+    // MARK: - Defensive Day-1 Tests
+
+    @Test("runCleanup with zero persons exits cleanly and invokes no cleanup")
+    func runCleanup_noPersons_stillExitsCleanly() async {
+        let fixture = Self.makeFixture()
+
+        await fixture.coordinator.runCleanup()
+
+        #expect(fixture.cleanupService.cleanOrphansCalls.isEmpty)
+        #expect(fixture.personRepository.fetchAllCallCount == 1)
+    }
+
+    @Test("runCleanup is a no-op when fetchAll throws")
+    func runCleanup_fetchAllFails_isNoOp() async throws {
+        let fixture = Self.makeFixture()
+        try fixture.personRepository.addPerson(Person(name: "Alice"))
+        fixture.personRepository.shouldFailFetchAll = true
+
+        await fixture.coordinator.runCleanup()
+
+        #expect(fixture.cleanupService.cleanOrphansCalls.isEmpty)
+        #expect(fixture.personRepository.fetchAllCallCount == 1)
+    }
+
+    @Test("runCleanup completes cleanly when cleanup reports orphans freed (info-log path)")
+    func runCleanup_logsSummaryOnSuccess() async throws {
+        let fixture = Self.makeFixture()
+        try fixture.personRepository.addPerson(Person(name: "Alice"))
+        fixture.cleanupService.cleanOrphansResult = CleanupResult(orphanCount: 3, freedBytes: 1_024)
+
+        await fixture.coordinator.runCleanup()
+
+        // The coordinator must exercise the info-log branch (orphanCount > 0) without crashing
+        #expect(fixture.cleanupService.cleanOrphansCalls.count == 1)
+    }
+}

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Attachment/LaunchOrphanCleanupCoordinatorTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Attachment/LaunchOrphanCleanupCoordinatorTests.swift
@@ -101,8 +101,8 @@ struct LaunchOrphanCleanupCoordinatorTests {
         #expect(fixture.personRepository.fetchAllCallCount == 1)
     }
 
-    @Test("runCleanup completes cleanly when cleanup reports orphans freed (info-log path)")
-    func runCleanup_logsSummaryOnSuccess() async throws {
+    @Test("runCleanup completes cleanly when a person has orphans freed")
+    func runCleanup_whenOrphansFreed_completesCleanly() async throws {
         let fixture = Self.makeFixture()
         try fixture.personRepository.addPerson(Person(name: "Alice"))
         fixture.cleanupService.cleanOrphansResult = CleanupResult(orphanCount: 3, freedBytes: 1_024)
@@ -111,5 +111,28 @@ struct LaunchOrphanCleanupCoordinatorTests {
 
         // The coordinator must exercise the info-log branch (orphanCount > 0) without crashing
         #expect(fixture.cleanupService.cleanOrphansCalls.count == 1)
+    }
+
+    // MARK: - Cancellation
+
+    @Test("runCleanup skips all persons when Task is already cancelled")
+    func runCleanup_alreadyCancelled_skipsAllPersons() async throws {
+        let fixture = Self.makeFixture()
+        try fixture.personRepository.addPerson(Person(name: "Alice"))
+        try fixture.personRepository.addPerson(Person(name: "Bob"))
+
+        // Create the task and immediately cancel it before awaiting.
+        // Swift's cooperative scheduler won't run the task body until this test
+        // task suspends at `await task.value`, so the task starts life with
+        // isCancelled == true — no timing dependency.
+        let task = Task {
+            await fixture.coordinator.runCleanup()
+        }
+        task.cancel()
+        await task.value
+
+        // The isCancelled guard fires before the first loop iteration, so
+        // cleanOrphans is never called.
+        #expect(fixture.cleanupService.cleanOrphansCalls.isEmpty)
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Attachment/OrphanBlobCleanupServiceTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Attachment/OrphanBlobCleanupServiceTests.swift
@@ -1,0 +1,234 @@
+import CryptoKit
+import Foundation
+import Testing
+@testable import FamilyMedicalApp
+
+@Suite("OrphanBlobCleanupService Tests")
+struct OrphanBlobCleanupServiceTests {
+    // MARK: - Fixtures
+
+    private struct Fixture {
+        let service: OrphanBlobCleanupService
+        let blobService: MockDocumentBlobService
+        let queryService: MockDocumentReferenceQueryService
+        let personId: UUID
+        let primaryKey: SymmetricKey
+    }
+
+    private static func makeFixture() -> Fixture {
+        let blobService = MockDocumentBlobService()
+        let queryService = MockDocumentReferenceQueryService()
+        let personId = UUID()
+        let primaryKey = SymmetricKey(size: .bits256)
+        let service = OrphanBlobCleanupService(
+            blobService: blobService,
+            queryService: queryService
+        )
+        return Fixture(
+            service: service,
+            blobService: blobService,
+            queryService: queryService,
+            personId: personId,
+            primaryKey: primaryKey
+        )
+    }
+
+    // MARK: - cleanOrphans
+
+    @Test("cleanOrphans deletes blobs not referenced by any record")
+    func cleanOrphans_deletesOrphans() async throws {
+        let fixture = Self.makeFixture()
+        let orphanHMAC = Data([0x01, 0x02])
+        let referencedHMAC = Data([0x03, 0x04])
+
+        fixture.blobService.blobsOnDisk[fixture.personId] = [orphanHMAC, referencedHMAC]
+        fixture.blobService.blobSizes[orphanHMAC] = 2_048
+        fixture.queryService.allReferencedHMACsResult = [referencedHMAC]
+
+        let result = try await fixture.service.cleanOrphans(personId: fixture.personId, primaryKey: fixture.primaryKey)
+
+        #expect(result.orphanCount == 1)
+        #expect(result.freedBytes == 2_048)
+        #expect(fixture.blobService.deleteDirectCalls.count == 1)
+        #expect(fixture.blobService.deleteDirectCalls.first?.contentHMAC == orphanHMAC)
+    }
+
+    @Test("cleanOrphans returns zero when no orphans exist")
+    func cleanOrphans_noOrphans() async throws {
+        let fixture = Self.makeFixture()
+        let referencedHMAC = Data([0x01, 0x02])
+
+        fixture.blobService.blobsOnDisk[fixture.personId] = [referencedHMAC]
+        fixture.queryService.allReferencedHMACsResult = [referencedHMAC]
+
+        let result = try await fixture.service.cleanOrphans(personId: fixture.personId, primaryKey: fixture.primaryKey)
+
+        #expect(result.orphanCount == 0)
+        #expect(result.freedBytes == 0)
+        #expect(fixture.blobService.deleteDirectCalls.isEmpty)
+    }
+
+    @Test("cleanOrphans returns zero when person has no blobs")
+    func cleanOrphans_emptyDirectory() async throws {
+        let fixture = Self.makeFixture()
+        fixture.blobService.blobsOnDisk[fixture.personId] = []
+        fixture.queryService.allReferencedHMACsResult = []
+
+        let result = try await fixture.service.cleanOrphans(personId: fixture.personId, primaryKey: fixture.primaryKey)
+
+        #expect(result.orphanCount == 0)
+        #expect(result.freedBytes == 0)
+    }
+
+    @Test("cleanOrphans skips in-flight blobs")
+    func cleanOrphans_skipsInFlight() async throws {
+        let fixture = Self.makeFixture()
+        let orphanHMAC = Data([0x01, 0x02])
+        let inFlightHMAC = Data([0x03, 0x04])
+
+        fixture.blobService.blobsOnDisk[fixture.personId] = [orphanHMAC, inFlightHMAC]
+        fixture.blobService.blobSizes[orphanHMAC] = 1_024
+        fixture.blobService.inFlightHMACs = [inFlightHMAC]
+        fixture.queryService.allReferencedHMACsResult = []
+
+        let result = try await fixture.service.cleanOrphans(personId: fixture.personId, primaryKey: fixture.primaryKey)
+
+        #expect(result.orphanCount == 1)
+        #expect(result.freedBytes == 1_024)
+        let deletedHMACs = fixture.blobService.deleteDirectCalls.map(\.contentHMAC)
+        #expect(deletedHMACs.contains(orphanHMAC))
+        #expect(!deletedHMACs.contains(inFlightHMAC))
+    }
+
+    @Test("cleanOrphans continues after individual delete failure and counts partial success")
+    func cleanOrphans_partialFailure() async throws {
+        let fixture = Self.makeFixture()
+        let failingHMAC = Data([0x01])
+        let succeedingHMAC = Data([0x02])
+
+        fixture.blobService.blobsOnDisk[fixture.personId] = [failingHMAC, succeedingHMAC]
+        fixture.blobService.blobSizes[failingHMAC] = 512
+        fixture.blobService.blobSizes[succeedingHMAC] = 1_024
+        fixture.queryService.allReferencedHMACsResult = []
+        fixture.blobService.deleteDirectFailForHMACs = [failingHMAC]
+
+        let result = try await fixture.service.cleanOrphans(personId: fixture.personId, primaryKey: fixture.primaryKey)
+
+        #expect(fixture.blobService.deleteDirectCalls.count == 2)
+        #expect(result.orphanCount == 1)
+        #expect(result.freedBytes == 1_024)
+    }
+
+    @Test("cleanOrphans propagates listBlobs errors")
+    func cleanOrphans_propagatesListBlobsError() async throws {
+        let fixture = Self.makeFixture()
+        fixture.blobService.listBlobsError = ModelError.documentStorageFailed(reason: "list failed")
+        fixture.queryService.allReferencedHMACsResult = []
+
+        await #expect(throws: ModelError.self) {
+            _ = try await fixture.service.cleanOrphans(personId: fixture.personId, primaryKey: fixture.primaryKey)
+        }
+        #expect(fixture.blobService.deleteDirectCalls.isEmpty)
+    }
+
+    @Test("cleanOrphans propagates allReferencedHMACs errors")
+    func cleanOrphans_propagatesAllReferencedHMACsError() async throws {
+        let fixture = Self.makeFixture()
+        fixture.queryService.allReferencedHMACsError = ModelError.documentStorageFailed(reason: "query failed")
+        fixture.blobService.blobsOnDisk[fixture.personId] = [Data([0x01])]
+
+        await #expect(throws: ModelError.self) {
+            _ = try await fixture.service.cleanOrphans(personId: fixture.personId, primaryKey: fixture.primaryKey)
+        }
+        #expect(fixture.blobService.deleteDirectCalls.isEmpty)
+    }
+
+    @Test("cleanOrphans skips blobs whose size lookup fails but continues scanning")
+    func cleanOrphans_blobSizeFailureIsTreatedAsPartialFailure() async throws {
+        let fixture = Self.makeFixture()
+        let sizeFailHMAC = Data([0x01])
+        let goodHMAC = Data([0x02])
+
+        fixture.blobService.blobsOnDisk[fixture.personId] = [sizeFailHMAC, goodHMAC]
+        fixture.blobService.blobSizes[goodHMAC] = 2_048
+        fixture.blobService.blobSizeFailForHMACs = [sizeFailHMAC]
+        fixture.queryService.allReferencedHMACsResult = []
+
+        let result = try await fixture.service.cleanOrphans(personId: fixture.personId, primaryKey: fixture.primaryKey)
+
+        // Only the good HMAC is counted and deleted; the size-fail HMAC is skipped.
+        #expect(result.orphanCount == 1)
+        #expect(result.freedBytes == 2_048)
+        let deletedHMACs = fixture.blobService.deleteDirectCalls.map(\.contentHMAC)
+        #expect(deletedHMACs.contains(goodHMAC))
+        #expect(!deletedHMACs.contains(sizeFailHMAC))
+    }
+
+    // MARK: - countOrphans
+
+    @Test("countOrphans reports counts without deleting")
+    func countOrphans_dryRun() async throws {
+        let fixture = Self.makeFixture()
+        let orphanHMAC = Data([0x01, 0x02])
+
+        fixture.blobService.blobsOnDisk[fixture.personId] = [orphanHMAC]
+        fixture.blobService.blobSizes[orphanHMAC] = 4_096
+        fixture.queryService.allReferencedHMACsResult = []
+
+        let result = try await fixture.service.countOrphans(personId: fixture.personId, primaryKey: fixture.primaryKey)
+
+        #expect(result.orphanCount == 1)
+        #expect(result.freedBytes == 4_096)
+        #expect(fixture.blobService.deleteDirectCalls.isEmpty)
+    }
+
+    @Test("countOrphans skips in-flight blobs without deleting")
+    func countOrphans_skipsInFlight() async throws {
+        let fixture = Self.makeFixture()
+        let orphanHMAC = Data([0x01, 0x02])
+        let inFlightHMAC = Data([0x03, 0x04])
+
+        fixture.blobService.blobsOnDisk[fixture.personId] = [orphanHMAC, inFlightHMAC]
+        fixture.blobService.blobSizes[orphanHMAC] = 1_024
+        fixture.blobService.blobSizes[inFlightHMAC] = 4_096
+        fixture.blobService.inFlightHMACs = [inFlightHMAC]
+        fixture.queryService.allReferencedHMACsResult = []
+
+        let result = try await fixture.service.countOrphans(personId: fixture.personId, primaryKey: fixture.primaryKey)
+
+        #expect(result.orphanCount == 1)
+        #expect(result.freedBytes == 1_024)
+        #expect(fixture.blobService.deleteDirectCalls.isEmpty)
+    }
+
+    @Test("countOrphans propagates listBlobs errors")
+    func countOrphans_propagatesErrors() async throws {
+        let fixture = Self.makeFixture()
+        fixture.blobService.listBlobsError = ModelError.documentStorageFailed(reason: "list failed")
+        fixture.queryService.allReferencedHMACsResult = []
+
+        await #expect(throws: ModelError.self) {
+            _ = try await fixture.service.countOrphans(personId: fixture.personId, primaryKey: fixture.primaryKey)
+        }
+        #expect(fixture.blobService.deleteDirectCalls.isEmpty)
+    }
+
+    @Test("countOrphans skips blobs whose size lookup fails")
+    func countOrphans_blobSizeFailureIsSkipped() async throws {
+        let fixture = Self.makeFixture()
+        let sizeFailHMAC = Data([0x01])
+        let goodHMAC = Data([0x02])
+
+        fixture.blobService.blobsOnDisk[fixture.personId] = [sizeFailHMAC, goodHMAC]
+        fixture.blobService.blobSizes[goodHMAC] = 2_048
+        fixture.blobService.blobSizeFailForHMACs = [sizeFailHMAC]
+        fixture.queryService.allReferencedHMACsResult = []
+
+        let result = try await fixture.service.countOrphans(personId: fixture.personId, primaryKey: fixture.primaryKey)
+
+        // One bad blob doesn't poison the whole scan; the usable ones still count.
+        #expect(result.orphanCount == 1)
+        #expect(result.freedBytes == 2_048)
+        #expect(fixture.blobService.deleteDirectCalls.isEmpty)
+    }
+}

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Records/DocumentReferenceQueryServiceTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Records/DocumentReferenceQueryServiceTests.swift
@@ -224,4 +224,51 @@ struct DocumentReferenceQueryServiceTests {
         )
         #expect(referenced == false)
     }
+
+    // MARK: - allReferencedHMACs
+
+    @Test("allReferencedHMACs returns set of contentHMAC values from all DocumentReferenceRecords")
+    func allReferencedHMACs() async throws {
+        let ctx = Self.makeFixture()
+        let hmac1 = Data([0x01, 0x02, 0x03])
+        let hmac2 = Data([0x04, 0x05, 0x06])
+
+        _ = try Self.persist(
+            DocumentReferenceRecord(
+                title: "doc1.pdf",
+                mimeType: "application/pdf",
+                fileSize: 100,
+                contentHMAC: hmac1
+            ),
+            in: ctx
+        )
+        _ = try Self.persist(
+            DocumentReferenceRecord(
+                title: "doc2.jpg",
+                mimeType: "image/jpeg",
+                fileSize: 200,
+                contentHMAC: hmac2
+            ),
+            in: ctx
+        )
+
+        let result = try await ctx.service.allReferencedHMACs(
+            personId: ctx.personId,
+            primaryKey: ctx.primaryKey
+        )
+
+        #expect(result == Set([hmac1, hmac2]))
+    }
+
+    @Test("allReferencedHMACs returns empty set when no DocumentReferenceRecords exist")
+    func allReferencedHMACs_empty() async throws {
+        let ctx = Self.makeFixture()
+
+        let result = try await ctx.service.allReferencedHMACs(
+            personId: ctx.personId,
+            primaryKey: ctx.primaryKey
+        )
+
+        #expect(result.isEmpty)
+    }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Records/DocumentReferenceQueryServiceTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Records/DocumentReferenceQueryServiceTests.swift
@@ -271,4 +271,67 @@ struct DocumentReferenceQueryServiceTests {
 
         #expect(result.isEmpty)
     }
+
+    @Test("allReferencedHMACs deduplicates records sharing the same contentHMAC")
+    func allReferencedHMACs_deduplication() async throws {
+        let ctx = Self.makeFixture()
+        let sharedHMAC = Data([0xAB, 0xCD])
+
+        _ = try Self.persist(
+            DocumentReferenceRecord(title: "A", mimeType: "image/jpeg", fileSize: 1, contentHMAC: sharedHMAC),
+            in: ctx
+        )
+        _ = try Self.persist(
+            DocumentReferenceRecord(title: "B", mimeType: "image/jpeg", fileSize: 1, contentHMAC: sharedHMAC),
+            in: ctx
+        )
+
+        let result = try await ctx.service.allReferencedHMACs(
+            personId: ctx.personId,
+            primaryKey: ctx.primaryKey
+        )
+
+        #expect(result == Set([sharedHMAC]))
+        #expect(result.count == 1)
+    }
+
+    @Test("allReferencedHMACs for one person does not return another person's HMACs")
+    func allReferencedHMACs_perPersonIsolation() async throws {
+        let ctx = Self.makeFixture()
+        let hmacA = Data([0xAA, 0xAA])
+        let hmacB = Data([0xBB, 0xBB])
+
+        // Record for the primary person
+        _ = try Self.persist(
+            DocumentReferenceRecord(title: "personA doc", mimeType: "image/jpeg", fileSize: 1, contentHMAC: hmacA),
+            in: ctx
+        )
+
+        // Build a record for a different person by encrypting with the mock content service
+        // (which ignores the actual key value) and stamping a different personId.
+        let otherPersonId = UUID()
+        let envelope = try RecordContentEnvelope(
+            DocumentReferenceRecord(title: "personB doc", mimeType: "image/jpeg", fileSize: 1, contentHMAC: hmacB)
+        )
+        let encrypted = try ctx.contentService.encrypt(envelope, using: ctx.fmk)
+        let otherRecord = MedicalRecord(
+            id: UUID(),
+            personId: otherPersonId,
+            encryptedContent: encrypted,
+            createdAt: Date(),
+            updatedAt: Date(),
+            version: 1,
+            previousVersionId: nil
+        )
+        ctx.recordRepo.addRecord(otherRecord)
+
+        // Query for ctx.personId — should only get hmacA, not hmacB.
+        let result = try await ctx.service.allReferencedHMACs(
+            personId: ctx.personId,
+            primaryKey: ctx.primaryKey
+        )
+
+        #expect(result == Set([hmacA]))
+        #expect(!result.contains(hmacB))
+    }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/ViewModels/Documents/DocumentPickerViewModelTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/ViewModels/Documents/DocumentPickerViewModelTests.swift
@@ -239,6 +239,21 @@ struct DocumentPickerViewModelTests {
     }
 
     @Test
+    func addFromCamera_marksHMACAsInFlight() async throws {
+        let fixtures = makeFixtures()
+        let image = makeTestImage()
+
+        await fixtures.viewModel.addFromCamera(image)
+
+        // storeAndAppend should have marked the stored blob's HMAC as in-flight
+        // so the orphan scanner doesn't reclaim it before the record is saved.
+        #expect(fixtures.blobService.markInFlightCalls.count == 1)
+        let draftHMAC = try #require(fixtures.viewModel.drafts.first?.content.contentHMAC)
+        #expect(fixtures.blobService.markInFlightCalls.first == draftHMAC)
+        #expect(fixtures.blobService.inFlightHMACs.contains(draftHMAC))
+    }
+
+    @Test
     func addFromCamera_populatesDocumentMetadata() async throws {
         let fixtures = makeFixtures()
         let image = makeTestImage()
@@ -278,6 +293,40 @@ struct DocumentPickerViewModelTests {
         fixtures.viewModel.removeDraft(id: UUID())
 
         #expect(fixtures.viewModel.drafts.count == 1)
+    }
+
+    @Test
+    func removeDraft_clearsInFlightForRemovedHMAC() async throws {
+        let fixtures = makeFixtures()
+        let image = makeTestImage()
+        await fixtures.viewModel.addFromCamera(image)
+
+        let draftId = try #require(fixtures.viewModel.drafts.first?.id)
+        let draftHMAC = try #require(fixtures.viewModel.drafts.first?.content.contentHMAC)
+
+        fixtures.viewModel.removeDraft(id: draftId)
+
+        // removeDraft fires its clearInFlight in a detached Task; give it a tick.
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        #expect(fixtures.viewModel.drafts.isEmpty)
+        #expect(fixtures.blobService.clearInFlightCalls.contains(draftHMAC))
+        #expect(!fixtures.blobService.inFlightHMACs.contains(draftHMAC))
+    }
+
+    @Test
+    func removeDraft_unknownId_doesNotClearInFlight() async throws {
+        let fixtures = makeFixtures()
+        let image = makeTestImage()
+        await fixtures.viewModel.addFromCamera(image)
+
+        fixtures.viewModel.removeDraft(id: UUID())
+
+        // Give any potential background Task a chance to run.
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // Nothing should have been cleared — the blob is still pending save.
+        #expect(fixtures.blobService.clearInFlightCalls.isEmpty)
     }
 
     // MARK: - Set Title Tests

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/ViewModels/Documents/DocumentPickerViewModelTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/ViewModels/Documents/DocumentPickerViewModelTests.swift
@@ -6,62 +6,6 @@ import UIKit
 
 @MainActor
 struct DocumentPickerViewModelTests {
-    // MARK: - Test Fixtures
-
-    struct TestFixtures {
-        let viewModel: DocumentPickerViewModel
-        let blobService: MockDocumentBlobService
-        let personId: UUID
-        let sourceRecordId: UUID?
-        let primaryKey: SymmetricKey
-    }
-
-    func makeFixtures(
-        sourceRecordId: UUID? = UUID(),
-        existing: [DocumentReferenceRecord] = []
-    ) -> TestFixtures {
-        let blobService = MockDocumentBlobService()
-        let primaryKey = SymmetricKey(size: .bits256)
-        let personId = UUID()
-
-        let viewModel = DocumentPickerViewModel(
-            personId: personId,
-            sourceRecordId: sourceRecordId,
-            primaryKey: primaryKey,
-            existing: existing,
-            blobService: blobService
-        )
-
-        return TestFixtures(
-            viewModel: viewModel,
-            blobService: blobService,
-            personId: personId,
-            sourceRecordId: sourceRecordId,
-            primaryKey: primaryKey
-        )
-    }
-
-    func makeTestImage(size: CGSize = CGSize(width: 100, height: 100)) -> UIImage {
-        let renderer = UIGraphicsImageRenderer(size: size)
-        return renderer.image { ctx in
-            UIColor.blue.setFill()
-            ctx.fill(CGRect(origin: .zero, size: size))
-        }
-    }
-
-    func makeDocumentReference(
-        title: String = "existing.jpg",
-        mimeType: String = "image/jpeg",
-        hmacByte: UInt8 = 0x01
-    ) -> DocumentReferenceRecord {
-        DocumentReferenceRecord(
-            title: title,
-            mimeType: mimeType,
-            fileSize: 1_024,
-            contentHMAC: Data(repeating: hmacByte, count: 32)
-        )
-    }
-
     // MARK: - Initialization Tests
 
     @Test
@@ -239,18 +183,20 @@ struct DocumentPickerViewModelTests {
     }
 
     @Test
-    func addFromCamera_marksHMACAsInFlight() async throws {
+    func addFromCamera_leavesHMACInFlightAfterStore() async throws {
         let fixtures = makeFixtures()
         let image = makeTestImage()
 
         await fixtures.viewModel.addFromCamera(image)
 
-        // storeAndAppend should have marked the stored blob's HMAC as in-flight
-        // so the orphan scanner doesn't reclaim it before the record is saved.
-        #expect(fixtures.blobService.markInFlightCalls.count == 1)
+        // `store` atomically marks the HMAC in-flight inside the blob actor, so the
+        // picker VM no longer needs to make an explicit markInFlight call. Assert the
+        // invariant that matters — state — rather than the mechanism — call count.
         let draftHMAC = try #require(fixtures.viewModel.drafts.first?.content.contentHMAC)
-        #expect(fixtures.blobService.markInFlightCalls.first == draftHMAC)
         #expect(fixtures.blobService.inFlightHMACs.contains(draftHMAC))
+        // The public markInFlight entry point should NOT have been called: `store`
+        // is responsible for the common path and uses direct set insertion.
+        #expect(fixtures.blobService.markInFlightCalls.isEmpty)
     }
 
     @Test
@@ -303,11 +249,19 @@ struct DocumentPickerViewModelTests {
 
         let draftId = try #require(fixtures.viewModel.drafts.first?.id)
         let draftHMAC = try #require(fixtures.viewModel.drafts.first?.content.contentHMAC)
+        // Precondition: the blob is in-flight — established by the atomic `store`
+        // contract rather than by an explicit markInFlight call.
+        #expect(fixtures.blobService.inFlightHMACs.contains(draftHMAC))
 
         fixtures.viewModel.removeDraft(id: draftId)
 
-        // removeDraft fires its clearInFlight in a detached Task; give it a tick.
-        try await Task.sleep(nanoseconds: 50_000_000)
+        // removeDraft fires its clearInFlight in a detached Task. Deterministic wait:
+        // yield up to 20 event-loop turns for the clear to land. This fails fast if
+        // the clear never happens and avoids the timing flakiness of Task.sleep.
+        for _ in 0 ..< 20 {
+            await Task.yield()
+            if !fixtures.blobService.inFlightHMACs.contains(draftHMAC) { break }
+        }
 
         #expect(fixtures.viewModel.drafts.isEmpty)
         #expect(fixtures.blobService.clearInFlightCalls.contains(draftHMAC))
@@ -315,17 +269,19 @@ struct DocumentPickerViewModelTests {
     }
 
     @Test
-    func removeDraft_unknownId_doesNotClearInFlight() async throws {
+    func removeDraft_unknownId_doesNotClearInFlight() async {
         let fixtures = makeFixtures()
         let image = makeTestImage()
         await fixtures.viewModel.addFromCamera(image)
 
         fixtures.viewModel.removeDraft(id: UUID())
 
-        // Give any potential background Task a chance to run.
-        try await Task.sleep(nanoseconds: 50_000_000)
+        // Yield a bounded number of turns to give any stray background Task a chance
+        // to run. Nothing should have been cleared — the blob is still pending save.
+        for _ in 0 ..< 20 {
+            await Task.yield()
+        }
 
-        // Nothing should have been cleared — the blob is still pending save.
         #expect(fixtures.blobService.clearInFlightCalls.isEmpty)
     }
 
@@ -400,5 +356,67 @@ struct DocumentPickerViewModelTests {
     func showingDocumentPicker_initiallyFalse() {
         let fixtures = makeFixtures()
         #expect(!fixtures.viewModel.showingDocumentPicker)
+    }
+}
+
+// MARK: - Fixtures and Helpers
+//
+// Lifted into an extension so they don't contribute to the primary type's
+// body-length budget (SwiftLint `type_body_length`).
+
+@MainActor
+extension DocumentPickerViewModelTests {
+    struct TestFixtures {
+        let viewModel: DocumentPickerViewModel
+        let blobService: MockDocumentBlobService
+        let personId: UUID
+        let sourceRecordId: UUID?
+        let primaryKey: SymmetricKey
+    }
+
+    func makeFixtures(
+        sourceRecordId: UUID? = UUID(),
+        existing: [DocumentReferenceRecord] = []
+    ) -> TestFixtures {
+        let blobService = MockDocumentBlobService()
+        let primaryKey = SymmetricKey(size: .bits256)
+        let personId = UUID()
+
+        let viewModel = DocumentPickerViewModel(
+            personId: personId,
+            sourceRecordId: sourceRecordId,
+            primaryKey: primaryKey,
+            existing: existing,
+            blobService: blobService
+        )
+
+        return TestFixtures(
+            viewModel: viewModel,
+            blobService: blobService,
+            personId: personId,
+            sourceRecordId: sourceRecordId,
+            primaryKey: primaryKey
+        )
+    }
+
+    func makeTestImage(size: CGSize = CGSize(width: 100, height: 100)) -> UIImage {
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { ctx in
+            UIColor.blue.setFill()
+            ctx.fill(CGRect(origin: .zero, size: size))
+        }
+    }
+
+    func makeDocumentReference(
+        title: String = "existing.jpg",
+        mimeType: String = "image/jpeg",
+        hmacByte: UInt8 = 0x01
+    ) -> DocumentReferenceRecord {
+        DocumentReferenceRecord(
+            title: title,
+            mimeType: mimeType,
+            fileSize: 1_024,
+            contentHMAC: Data(repeating: hmacByte, count: 32)
+        )
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/ViewModels/Records/GenericRecordFormViewModelAttachmentTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/ViewModels/Records/GenericRecordFormViewModelAttachmentTests.swift
@@ -161,6 +161,73 @@ struct GenericRecordFormViewModelAttachmentTests {
     }
 
     @Test
+    func save_withPendingAttachments_clearsInFlightForEachSavedAttachment() async throws {
+        let person = try makeTestPerson()
+        let deps = FormViewModelDeps(personId: person.id)
+        let blobService = MockDocumentBlobService()
+        let vm = FormTestSupport.makeViewModel(
+            person: person,
+            recordType: .immunization,
+            deps: deps,
+            blobService: blobService
+        )
+        vm.setValue("Moderna", for: "vaccineCode")
+        vm.setValue(Date(), for: "occurrenceDate")
+
+        await vm.createDocumentPickerIfNeeded()
+        let pickerVM = try #require(vm.documentPickerViewModel)
+        await pickerVM.addFromDocumentPicker([makeTempPDFURL()])
+
+        // storeAndAppend should have marked the blob in-flight.
+        #expect(blobService.markInFlightCalls.count == 1)
+        let draftHMAC = try #require(pickerVM.drafts.first?.content.contentHMAC)
+        #expect(blobService.inFlightHMACs.contains(draftHMAC))
+
+        let ok = await vm.save()
+
+        #expect(ok == true)
+        // After the attachment record save, the form VM should have proxied
+        // clearInFlightForDraft through the picker to the blob service.
+        #expect(blobService.clearInFlightCalls.contains(draftHMAC))
+        #expect(!blobService.inFlightHMACs.contains(draftHMAC))
+    }
+
+    @Test
+    func save_attachmentSaveFails_leavesHMACInFlight() async throws {
+        let person = try makeTestPerson()
+        let deps = FormViewModelDeps(personId: person.id)
+        let blobService = MockDocumentBlobService()
+        let vm = FormTestSupport.makeViewModel(
+            person: person,
+            recordType: .immunization,
+            deps: deps,
+            blobService: blobService
+        )
+        vm.setValue("Moderna", for: "vaccineCode")
+        vm.setValue(Date(), for: "occurrenceDate")
+
+        await vm.createDocumentPickerIfNeeded()
+        let pickerVM = try #require(vm.documentPickerViewModel)
+        await pickerVM.addFromDocumentPicker([makeTempPDFURL()])
+
+        let draftHMAC = try #require(pickerVM.drafts.first?.content.contentHMAC)
+        #expect(blobService.inFlightHMACs.contains(draftHMAC))
+
+        // Fail on attachment save (second call), succeed on parent (first).
+        deps.repo.failOnSaveCallNumber = 2
+
+        let ok = await vm.save()
+
+        // Parent saved, overall returns true but attachment save failed.
+        #expect(ok == true)
+        #expect(vm.errorMessage != nil)
+        // Crucially: in-flight state is NOT cleared for the failed attachment so a
+        // subsequent retry still has the blob on disk.
+        #expect(!blobService.clearInFlightCalls.contains(draftHMAC))
+        #expect(blobService.inFlightHMACs.contains(draftHMAC))
+    }
+
+    @Test
     func save_attachmentSaveError_doesNotFailParent() async throws {
         let person = try makeTestPerson()
         let deps = FormViewModelDeps(personId: person.id)

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/ViewModels/Records/GenericRecordFormViewModelAttachmentTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/ViewModels/Records/GenericRecordFormViewModelAttachmentTests.swift
@@ -176,20 +176,34 @@ struct GenericRecordFormViewModelAttachmentTests {
 
         await vm.createDocumentPickerIfNeeded()
         let pickerVM = try #require(vm.documentPickerViewModel)
-        await pickerVM.addFromDocumentPicker([makeTempPDFURL()])
+        // Two distinct PDFs so their SHA256-based synthetic HMACs don't collide.
+        // The mock's synthetic HMAC is computed from the raw bytes, so different
+        // payloads guarantee two separate in-flight entries and two clearInFlight
+        // calls on save — the "for each" part of the test's promise.
+        await pickerVM.addFromDocumentPicker([
+            makeTempPDFURL(payload: "content-one"),
+            makeTempPDFURL(payload: "content-two")
+        ])
 
-        // storeAndAppend should have marked the blob in-flight.
-        #expect(blobService.markInFlightCalls.count == 1)
-        let draftHMAC = try #require(pickerVM.drafts.first?.content.contentHMAC)
-        #expect(blobService.inFlightHMACs.contains(draftHMAC))
+        #expect(pickerVM.drafts.count == 2)
+        // Atomic `store` contract: both drafts are in-flight immediately after append,
+        // without any explicit markInFlight call from the picker VM.
+        let firstHMAC = try #require(pickerVM.drafts.first?.content.contentHMAC)
+        let secondHMAC = try #require(pickerVM.drafts.last?.content.contentHMAC)
+        #expect(firstHMAC != secondHMAC)
+        #expect(blobService.inFlightHMACs.contains(firstHMAC))
+        #expect(blobService.inFlightHMACs.contains(secondHMAC))
 
         let ok = await vm.save()
 
         #expect(ok == true)
         // After the attachment record save, the form VM should have proxied
-        // clearInFlightForDraft through the picker to the blob service.
-        #expect(blobService.clearInFlightCalls.contains(draftHMAC))
-        #expect(!blobService.inFlightHMACs.contains(draftHMAC))
+        // clearInFlightForDraft through the picker to the blob service for EACH
+        // saved attachment — not just the first.
+        #expect(blobService.clearInFlightCalls.contains(firstHMAC))
+        #expect(blobService.clearInFlightCalls.contains(secondHMAC))
+        #expect(!blobService.inFlightHMACs.contains(firstHMAC))
+        #expect(!blobService.inFlightHMACs.contains(secondHMAC))
     }
 
     @Test
@@ -363,11 +377,13 @@ struct GenericRecordFormViewModelAttachmentTests {
         return DecryptedRecord(record: record, envelope: envelope)
     }
 
-    private func makeTempPDFURL() -> URL {
+    private func makeTempPDFURL(payload: String = "test content") -> URL {
         let tempDir = FileManager.default.temporaryDirectory
         let fileURL = tempDir.appendingPathComponent("test_\(UUID().uuidString).pdf")
-        // PDF magic bytes
-        let pdfData = Data("%PDF-1.4 test content".utf8)
+        // PDF magic bytes plus caller-chosen payload so distinct calls produce
+        // distinct byte sequences (and therefore distinct SHA256-based HMACs in
+        // the mock blob service — important for multi-attachment tests).
+        let pdfData = Data("%PDF-1.4 \(payload)".utf8)
         try? pdfData.write(to: fileURL)
         return fileURL
     }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/ViewModels/Records/MedicalRecordListViewModelCascadeDeleteTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/ViewModels/Records/MedicalRecordListViewModelCascadeDeleteTests.swift
@@ -160,7 +160,10 @@ struct MedicalRecordListViewModelCascadeDeleteTests {
         #expect(viewModel.records.isEmpty)
         #expect(deps.repo.deleteCallCount == 2)
         #expect(deps.blobService.deleteCalls.count == 1)
-        #expect(deps.blobService.deleteCalls.first == hmac)
+        let call = try #require(deps.blobService.deleteCalls.first)
+        #expect(call.contentHMAC == hmac)
+        #expect(call.personId == person.id)
+        #expect(call.isReferencedElsewhere == false)
     }
 
     // MARK: - DeletionStrategy.keepStandalone

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/ViewModels/Records/MedicalRecordListViewModelTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/ViewModels/Records/MedicalRecordListViewModelTests.swift
@@ -368,6 +368,9 @@ struct MedicalRecordListViewModelTests {
 
         // Blob deletion proceeds when prefetch succeeds
         #expect(mockBlobService.deleteCalls.count == 1)
-        #expect(mockBlobService.deleteCalls[0] == hmac)
+        let call = try #require(mockBlobService.deleteCalls.first)
+        #expect(call.contentHMAC == hmac)
+        #expect(call.personId == person.id)
+        #expect(call.isReferencedElsewhere == false)
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Settings/SettingsViewModelCleanupTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Settings/SettingsViewModelCleanupTests.swift
@@ -1,0 +1,176 @@
+import CryptoKit
+import Foundation
+import Testing
+@testable import FamilyMedicalApp
+
+@Suite("SettingsViewModel Storage Cleanup Tests")
+struct SettingsViewModelCleanupTests {
+    // MARK: - Fixture
+
+    /// Bundle of collaborators wired for cleanup tests. Keeping references to the mocks
+    /// lets each test assert against call counts / configure stub values.
+    @MainActor
+    struct Fixture {
+        let viewModel: SettingsViewModel
+        let cleanupService: MockOrphanBlobCleanupService
+        let personRepository: MockPersonRepository
+    }
+
+    @MainActor
+    static func makeFixture() -> Fixture {
+        let cleanupService = MockOrphanBlobCleanupService()
+        let personRepository = MockPersonRepository()
+        let viewModel = SettingsViewModel(
+            exportService: MockExportService(),
+            importService: MockImportService(),
+            backupFileService: MockBackupFileService(),
+            logExportService: MockLogExportService(),
+            cleanupService: cleanupService,
+            personRepository: personRepository
+        )
+        return Fixture(
+            viewModel: viewModel,
+            cleanupService: cleanupService,
+            personRepository: personRepository
+        )
+    }
+
+    /// Build a persisted `Person` for repository setup. Person's init throws so tests
+    /// use `try` and a guaranteed-valid name.
+    static func makePerson(name: String = "Alice") throws -> Person {
+        try Person(name: name)
+    }
+
+    // MARK: - checkStorage Happy Paths
+
+    @Test("checkStorage aggregates orphan counts across persons and shows confirmation when orphans exist")
+    @MainActor
+    func checkStorage_withOrphans() async throws {
+        let fixture = Self.makeFixture()
+        let personA = try Self.makePerson(name: "Alice")
+        let personB = try Self.makePerson(name: "Bob")
+        fixture.personRepository.addPerson(personA)
+        fixture.personRepository.addPerson(personB)
+        fixture.cleanupService.countOrphansResult = CleanupResult(orphanCount: 2, freedBytes: 1_024)
+
+        let primaryKey = SymmetricKey(size: .bits256)
+        await fixture.viewModel.checkStorage(primaryKey: primaryKey)
+
+        // Persons come back sorted by name, so Alice then Bob
+        #expect(fixture.cleanupService.countOrphansCalls == [personA.id, personB.id])
+        #expect(fixture.viewModel.cleanupDryRunResult?.orphanCount == 4)
+        #expect(fixture.viewModel.cleanupDryRunResult?.freedBytes == 2_048)
+        #expect(fixture.viewModel.showingCleanupConfirmation)
+        #expect(!fixture.viewModel.showingCleanupResult)
+        #expect(!fixture.viewModel.isCheckingStorage)
+    }
+
+    @Test("checkStorage shows result directly when no orphans exist")
+    @MainActor
+    func checkStorage_noOrphans() async throws {
+        let fixture = Self.makeFixture()
+        try fixture.personRepository.addPerson(Self.makePerson())
+        fixture.cleanupService.countOrphansResult = CleanupResult(orphanCount: 0, freedBytes: 0)
+
+        await fixture.viewModel.checkStorage(primaryKey: SymmetricKey(size: .bits256))
+
+        #expect(!fixture.viewModel.showingCleanupConfirmation)
+        #expect(fixture.viewModel.showingCleanupResult)
+        #expect(fixture.viewModel.cleanupResult?.orphanCount == 0)
+    }
+
+    // MARK: - performCleanup Happy Paths
+
+    @Test("performCleanup aggregates cleanOrphans results and shows result alert")
+    @MainActor
+    func performCleanup_success() async throws {
+        let fixture = Self.makeFixture()
+        try fixture.personRepository.addPerson(Self.makePerson())
+        fixture.cleanupService.cleanOrphansResult = CleanupResult(orphanCount: 3, freedBytes: 4_096)
+
+        await fixture.viewModel.performCleanup(primaryKey: SymmetricKey(size: .bits256))
+
+        #expect(fixture.cleanupService.cleanOrphansCalls.count == 1)
+        #expect(fixture.viewModel.cleanupResult?.orphanCount == 3)
+        #expect(fixture.viewModel.cleanupResult?.freedBytes == 4_096)
+        #expect(fixture.viewModel.showingCleanupResult)
+        #expect(!fixture.viewModel.showingCleanupConfirmation)
+        #expect(!fixture.viewModel.isCleaningStorage)
+    }
+
+    @Test("performCleanup surfaces error message on cleanupService failure")
+    @MainActor
+    func performCleanup_failure() async throws {
+        let fixture = Self.makeFixture()
+        try fixture.personRepository.addPerson(Self.makePerson())
+        fixture.cleanupService.cleanOrphansError = RepositoryError.saveFailed("disk locked")
+
+        await fixture.viewModel.performCleanup(primaryKey: SymmetricKey(size: .bits256))
+
+        #expect(fixture.viewModel.errorMessage == "Some files could not be cleaned up.")
+        #expect(!fixture.viewModel.showingCleanupResult)
+        #expect(!fixture.viewModel.isCleaningStorage)
+    }
+
+    // MARK: - Defensive Tests
+
+    @Test("checkStorage surfaces error when personRepository fails")
+    @MainActor
+    func checkStorage_personRepositoryFailure() async {
+        let fixture = Self.makeFixture()
+        fixture.personRepository.shouldFailFetchAll = true
+
+        await fixture.viewModel.checkStorage(primaryKey: SymmetricKey(size: .bits256))
+
+        #expect(fixture.viewModel.errorMessage == "Unable to check storage. Please try again.")
+        #expect(!fixture.viewModel.showingCleanupConfirmation)
+        #expect(!fixture.viewModel.showingCleanupResult)
+    }
+
+    @Test("checkStorage surfaces error when countOrphans fails")
+    @MainActor
+    func checkStorage_countOrphansFailure() async throws {
+        let fixture = Self.makeFixture()
+        try fixture.personRepository.addPerson(Self.makePerson())
+        fixture.cleanupService.countOrphansError = RepositoryError.fetchFailed("disk error")
+
+        await fixture.viewModel.checkStorage(primaryKey: SymmetricKey(size: .bits256))
+
+        #expect(fixture.viewModel.errorMessage == "Unable to check storage. Please try again.")
+        #expect(!fixture.viewModel.showingCleanupConfirmation)
+    }
+
+    @Test("checkStorage clears stale dryRunResult before running")
+    @MainActor
+    func checkStorage_clearsStaleDryRun() async {
+        let fixture = Self.makeFixture()
+        fixture.viewModel.cleanupDryRunResult = CleanupResult(orphanCount: 99, freedBytes: 99_999)
+        // No persons — loop is skipped, and aggregate should settle at 0/0 (not 99/99_999).
+        fixture.cleanupService.countOrphansResult = CleanupResult(orphanCount: 0, freedBytes: 0)
+
+        await fixture.viewModel.checkStorage(primaryKey: SymmetricKey(size: .bits256))
+
+        #expect(fixture.viewModel.cleanupDryRunResult?.orphanCount == 0)
+        #expect(fixture.viewModel.cleanupDryRunResult?.freedBytes == 0)
+    }
+
+    @Test("formattedCleanupSize returns empty string when no result present")
+    @MainActor
+    func formattedCleanupSize_noResult() {
+        let fixture = Self.makeFixture()
+        #expect(fixture.viewModel.formattedCleanupSize.isEmpty)
+    }
+
+    @Test("formattedCleanupSize prefers dryRunResult over cleanupResult")
+    @MainActor
+    func formattedCleanupSize_prefersDryRun() {
+        let fixture = Self.makeFixture()
+        fixture.viewModel.cleanupDryRunResult = CleanupResult(orphanCount: 5, freedBytes: 1_000)
+        fixture.viewModel.cleanupResult = CleanupResult(orphanCount: 10, freedBytes: 9_999_999)
+
+        // The dry-run formatted size is ~1 KB which will not contain "9".
+        let formatted = fixture.viewModel.formattedCleanupSize
+        #expect(!formatted.isEmpty)
+        #expect(!formatted.contains("9"))
+    }
+}

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Settings/SettingsViewModelCleanupTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Settings/SettingsViewModelCleanupTests.swift
@@ -154,23 +154,24 @@ struct SettingsViewModelCleanupTests {
         #expect(fixture.viewModel.cleanupDryRunResult?.freedBytes == 0)
     }
 
-    @Test("formattedCleanupSize returns empty string when no result present")
+    @Test("performCleanup cleanupResult does not reflect stale cleanupDryRunResult when totals diverge")
     @MainActor
-    func formattedCleanupSize_noResult() {
+    func performCleanup_cleanupResultIsolatedFromDryRun() async throws {
         let fixture = Self.makeFixture()
-        #expect(fixture.viewModel.formattedCleanupSize.isEmpty)
-    }
+        try fixture.personRepository.addPerson(Self.makePerson(name: "Alice"))
 
-    @Test("formattedCleanupSize prefers dryRunResult over cleanupResult")
-    @MainActor
-    func formattedCleanupSize_prefersDryRun() {
-        let fixture = Self.makeFixture()
-        fixture.viewModel.cleanupDryRunResult = CleanupResult(orphanCount: 5, freedBytes: 1_000)
-        fixture.viewModel.cleanupResult = CleanupResult(orphanCount: 10, freedBytes: 9_999_999)
+        // Dry-run finds 5 orphans, 2048 bytes
+        fixture.cleanupService.countOrphansResult = CleanupResult(orphanCount: 5, freedBytes: 2_048)
+        await fixture.viewModel.checkStorage(primaryKey: SymmetricKey(size: .bits256))
+        #expect(fixture.viewModel.cleanupDryRunResult?.orphanCount == 5)
+        #expect(fixture.viewModel.cleanupDryRunResult?.freedBytes == 2_048)
 
-        // The dry-run formatted size is ~1 KB which will not contain "9".
-        let formatted = fixture.viewModel.formattedCleanupSize
-        #expect(!formatted.isEmpty)
-        #expect(!formatted.contains("9"))
+        // But the real cleanup only frees 3 orphans / 1024 bytes (partial failure or race)
+        fixture.cleanupService.cleanOrphansResult = CleanupResult(orphanCount: 3, freedBytes: 1_024)
+        await fixture.viewModel.performCleanup(primaryKey: SymmetricKey(size: .bits256))
+
+        // cleanupResult must reflect the real cleanup, not the dry-run
+        #expect(fixture.viewModel.cleanupResult?.orphanCount == 3)
+        #expect(fixture.viewModel.cleanupResult?.freedBytes == 1_024)
     }
 }


### PR DESCRIPTION
Closes #151 (part of epic #120).

## Summary
- Adds automatic and manual cleanup of orphaned encrypted attachment blobs: `orphans = blobsOnDisk − referencedByRecords − inFlightWrites`, computed per person.
- Blobs now live at `Attachments/{personId}/{hmac}.enc` (was `Attachments/{hmac}.enc`). `DocumentBlobService` is now a Swift actor with atomic in-flight tracking. New `OrphanBlobCleanupService` scans and deletes; new `LaunchOrphanCleanupCoordinator` runs it silently at app launch / lock-unlock; new Settings → Storage Management → "Clean Up Storage" runs it manually with a dry-run → confirmation → result flow.

## ⚠️ Dev-install note (read before pulling)
This refactors the on-disk layout from flat `Attachments/*.enc` to per-person subdirectories `Attachments/{personId}/{hmac}.enc`. No production users → no migration logic was built. **Any dev simulator with pre-existing attachments will find them unreadable AND unreclaimable** (records reference HMACs that no longer resolve, and the cleanup scanner only enumerates per-person subdirs so the flat files are stranded). **Delete the app from your simulator before checking out this branch.**

## Key design decision: the store↔in-flight race
An earlier design marked blobs in-flight in a *second* actor hop after `store` returned. That left a window where the cleanup scanner could interleave between the two hops — observing a just-stored blob on disk without the in-flight bit, and deleting it mid-save. Real bug, and exactly the race the in-flight set was supposed to close.

Fix (commit \`b072e15\`): \`inFlightHMACs.insert(hmac)\` now runs inside the same actor-isolated body as the file-storage write, with no intervening \`await\`. Because \`fileStorage\` is synchronous from the actor's perspective, the actor never yields between disk write and in-flight mark — interleaving is structurally impossible. The mock mirrors the contract so viewmodel tests exercise the same semantics. See \`DocumentBlobService.swift:139-183\`.

## What changes for users
- **Settings > Storage Management**: new "Clean Up Storage" button. Dry-run scan → confirmation dialog with orphan count + size → cleanup → result alert. Silent if zero orphans.
- **App launch (and lock → unlock)**: silent best-effort background sweep.
- **Draft flow**: attaching a file marks the blob in-flight as part of the store; removing a draft or saving the record clears it. Orphan scanner never deletes a blob pending a record save.

## API surface changes (internal module)
- \`DocumentBlobServiceProtocol\` gains 6 methods: \`listBlobs\`, \`blobSize\`, \`deleteDirect\`, \`markInFlight\`, \`clearInFlight\`, \`isInFlight\`. Service is now an \`actor\` (was \`final class @unchecked Sendable\`).
- \`DocumentFileStorageServiceProtocol\` gains a required \`personId: UUID\` parameter on every method + new \`listBlobs\` / \`blobSize\`.
- \`DocumentReferenceQueryServiceProtocol\` gains \`allReferencedHMACs(personId:primaryKey:)\`.
- \`FamilyMemberKeyServiceProtocol\` now requires \`Sendable\` (strict-concurrency dependency of the actor).
- New: \`OrphanBlobCleanupService\`, \`OrphanBlobCleanupServiceProtocol\`, \`CleanupResult\`, \`LaunchOrphanCleanupCoordinator\`.

## Test coverage
- **1606 passing / 0 failing / 3 pre-existing skips**
- **Overall coverage 85.04%**, all files meet their 85% threshold
- New services unit-tested including failure paths: per-HMAC \`blobSize\` failure, per-HMAC \`deleteDirect\` failure, per-person cleanup failure, in-flight race ordering, launch cancellation mid-sweep, stale-dry-run clearing, per-person isolation, deduplication
- **No end-to-end integration test** — every seam is covered individually against mocks. See "Follow-ups" below.

## Scope pulled forward
The plan originally sequenced some signature changes across tasks, creating artificial windows where intermediate states had latent bugs. Per the \"day 1 correct\" standard I pulled a few of those forward:
- \`deleteIfUnreferenced(personId:)\` signature pulled from Task 2 into Task 1 (otherwise \`UUID()\` placeholder would have silently leaked orphans on cascade delete).
- \`MedicalRecordListViewModel.cascadeDeleteAttachments\` \`person.id\` plumbing pulled from Task 5 into Task 1.

## Commits (18)
Per-task implementer → spec review → code-quality review → fix loops produced a clear commit history. Every task got both review passes before moving on.

## Test plan
- [ ] Delete the app from your simulator before checking out
- [ ] \`./scripts/run-tests.sh\` green locally
- [ ] \`./scripts/check-coverage.sh\` passes
- [ ] Manual: Settings → Storage Management → Clean Up Storage with zero orphans (result alert fires, no confirmation)
- [ ] Manual: create a record with an attachment, delete the record (cascade), verify the blob is reclaimed on next launch cleanup
- [ ] Manual: Settings → Clean Up Storage after the above (confirmation dialog → cleanup → result alert)
- [ ] Verify launch cleanup fires silently on cold launch and on lock → unlock

## Follow-ups (post-merge, non-blocking)
- [ ] End-to-end integration test wiring the real services against a tmpdir + in-memory Core Data stack (single happy-path test, ~80 lines)
- [ ] Consider renaming \`LaunchOrphanCleanupCoordinator\` → \`OrphanCleanupCoordinator\` since it runs on every \`.authenticated\` entry, not only cold launch
- [ ] Amend \`docs/superpowers/plans/2026-04-12-orphan-blob-cleanup.md\` to record the Task 5 race-fix deviation, or mark the plan as a historical snapshot

## Summary by Sourcery

Introduce per-person attachment storage and orphan blob cleanup, including background launch sweeps and a user-facing storage cleanup flow, while hardening blob handling against races via actor-based in-flight tracking.

New Features:
- Add an orphan blob cleanup service and launch-time coordinator to scan per-person attachments and remove unreferenced blobs.
- Expose a "Clean Up Storage" action in Settings with a dry-run, confirmation, and result flow for reclaiming orphaned attachment space.
- Support listing blobs, computing blob sizes, and unconditional deletion through the document blob APIs for use by cleanup logic.

Enhancements:
- Refactor document file storage to use per-person subdirectories for encrypted blobs and add tracing, list, and size operations.
- Convert the document blob service to an actor with explicit in-flight HMAC tracking to avoid races between saving and cleanup.
- Extend document reference querying to return all referenced HMACs per person and thread person IDs through delete paths for correct per-person cleanup.
- Wire form, picker, and list view models to mark blobs in-flight on attach and clear them on successful save or draft removal, preserving retry semantics.

Tests:
- Add comprehensive unit tests for document file storage, blob service in-flight and cleanup behavior, document reference querying, and orphan cleanup logic including partial failures and race conditions.
- Add tests for Settings storage cleanup state handling and launch-time cleanup coordination across multiple persons.