### PR TITLE
fix(scripts): accept id= in run-tests.sh --destination (#135)

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -148,11 +148,32 @@ rm -rf test-results* DerivedData/TestResults.xcresult
 # Disable hardware keyboard to prevent password autofill prompts from blocking XCUITest automation
 echo "Configuring simulator for UI testing..."
 
-# Extract device name from destination (e.g., "iPhone 17 Pro" from "platform=iOS Simulator,name=iPhone 17 Pro")
-DEVICE_NAME=$(echo "$DESTINATION" | sed -n 's/.*name=\([^,]*\).*/\1/p')
+# Parse destination as comma-separated key=value pairs.
+# xcodebuild accepts either name=... or id=... to identify a simulator; we require exactly one.
+DEVICE_NAME=""
+DEVICE_ID=""
+IFS=',' read -ra DEST_PARTS <<< "$DESTINATION"
+for part in "${DEST_PARTS[@]}"; do
+  case "$part" in
+    name=*) DEVICE_NAME="${part#name=}" ;;
+    id=*)   DEVICE_ID="${part#id=}" ;;
+  esac
+done
 
-# Find UDID for the device from simctl list
-if [ -n "$DEVICE_NAME" ]; then
+if [ -z "$DEVICE_NAME" ] && [ -z "$DEVICE_ID" ]; then
+  echo "Error: --destination must include either name=... or id=..."
+  exit 1
+fi
+if [ -n "$DEVICE_NAME" ] && [ -n "$DEVICE_ID" ]; then
+  echo "Error: --destination cannot include both name=... and id=..."
+  exit 1
+fi
+
+# Resolve UDID for simulator preference tweaks
+UDID=""
+if [ -n "$DEVICE_ID" ]; then
+  UDID="$DEVICE_ID"
+else
   # Match exact device name with " (" suffix to avoid "iPhone 17 Pro" matching "iPhone 17 Pro Max"
   # Uses last match since devices are listed oldest iOS first, newest last
   UDID=$(xcrun simctl list devices available 2>/dev/null | grep -F "$DEVICE_NAME (" | tail -1 | sed 's/.*(\([A-F0-9-]*\)).*/\1/' || echo "")
@@ -168,7 +189,11 @@ if [ -n "$UDID" ]; then
     ~/Library/Preferences/com.apple.iphonesimulator.plist 2>/dev/null || \
   /usr/libexec/PlistBuddy -c "Add :DevicePreferences:$UDID:ConnectHardwareKeyboard bool false" \
     ~/Library/Preferences/com.apple.iphonesimulator.plist
-  echo "  ✓ Hardware keyboard disabled for simulator $UDID ($DEVICE_NAME)"
+  if [ -n "$DEVICE_NAME" ]; then
+    echo "  ✓ Hardware keyboard disabled for simulator $UDID ($DEVICE_NAME)"
+  else
+    echo "  ✓ Hardware keyboard disabled for simulator $UDID"
+  fi
 else
   echo "  ⚠ Could not determine simulator UDID, hardware keyboard setting not changed"
 fi

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -154,6 +154,8 @@ DEVICE_NAME=""
 DEVICE_ID=""
 IFS=',' read -ra DEST_PARTS <<< "$DESTINATION"
 for part in "${DEST_PARTS[@]}"; do
+  # Strip leading whitespace so "platform=iOS Simulator, name=..." is tolerated
+  part="${part#"${part%%[![:space:]]*}"}"
   case "$part" in
     name=*) DEVICE_NAME="${part#name=}" ;;
     id=*)   DEVICE_ID="${part#id=}" ;;


### PR DESCRIPTION
## Summary

Fixes #135 — `scripts/run-tests.sh` previously only parsed the `name=` form of the `--destination` argument. When called with `platform=iOS Simulator,id=<UUID>` (the form recommended in `AGENTS.md`), `DEVICE_NAME` was empty, the `if [ -n "$DEVICE_NAME" ]` branch was skipped, and `UDID` was left unassigned. The subsequent `[ -z "$UDID" ]` check then tripped `set -u` with an unbound-variable error.

## Changes

- Parse `$DESTINATION` as comma-separated `key=value` pairs instead of a greedy `sed` regex (safer: won't accidentally match `id=` inside a value).
- Accept either `name=...` or `id=...`. Reject both-at-once and neither with a clear error.
- When `id=` is provided, use it directly as the `UDID` for the `PlistBuddy` hardware-keyboard tweak (no `simctl` lookup needed).
- Initialise `UDID=""` before any branch so `set -u` is safe on every code path.
- When only `id=` is known, drop the `(DEVICE_NAME)` suffix from the "Hardware keyboard disabled" log line rather than printing an empty `()`.

## Test plan

Verified locally in four combinations (all short-circuited before `xcodebuild` actually ran):

- [x] `name=iPhone 17,OS=26.2` (default) — parses, resolves real UDID via `simctl`, proceeds past parsing block
- [x] `id=<UUID>` — uses the UUID directly, proceeds past parsing block (previously crashed with unbound variable)
- [x] `name=...` AND `id=...` together — fails with `Error: --destination cannot include both name=... and id=...`
- [x] Neither `name=` nor `id=` — fails with `Error: --destination must include either name=... or id=...`
- [x] `bash -n` clean, `shellcheck` clean, `pre-commit` clean

Per project ethos (KISS/YAGNI, no existing shell test harness) no bash test infrastructure was introduced. CI will exercise the happy path.

## Summary by Sourcery

Ensure run-tests.sh correctly handles iOS simulator destinations identified by either name or id and safely configures hardware keyboard settings.

Bug Fixes:
- Fix handling of --destination arguments that specify simulators by id= to avoid unbound-variable errors under set -u.
- Prevent ambiguous or missing simulator identifiers by requiring exactly one of name=... or id=... in the --destination argument.
- Avoid misleading log output by omitting empty device name parentheses when only a simulator id is provided.

Enhancements:
- Parse the --destination argument as comma-separated key=value pairs and use a provided simulator id directly as the UDID for configuration.