### PR TITLE
refactor(tests): apply HostedInspection to all view tests (#145)

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -43,10 +43,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install pinned SwiftFormat
-        env:
-          # Keep in sync with .pre-commit-config.yaml SwiftFormat rev
-          SWIFTFORMAT_VERSION: 0.60.1
         run: |
+          # Single source of truth for the version: .pre-commit-config.yaml
+          SWIFTFORMAT_VERSION=$(awk '/nicklockwood\/SwiftFormat/{f=1; next} f && /rev:/{print $2; exit}' .pre-commit-config.yaml)
+          if [ -z "$SWIFTFORMAT_VERSION" ]; then
+            echo "::error::Could not extract SwiftFormat rev from .pre-commit-config.yaml"
+            exit 1
+          fi
           BIN_DIR="$RUNNER_TEMP/swiftformat-bin"
           mkdir -p "$BIN_DIR"
           curl -fsSL "https://github.com/nicklockwood/SwiftFormat/releases/download/${SWIFTFORMAT_VERSION}/swiftformat.zip" -o /tmp/swiftformat.zip

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -42,13 +42,17 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - run: brew install swiftformat
-      - name: Verify SwiftFormat version matches pre-commit
+      - name: Install pinned SwiftFormat
+        env:
+          # Keep in sync with .pre-commit-config.yaml SwiftFormat rev
+          SWIFTFORMAT_VERSION: 0.60.1
         run: |
+          curl -fsSL "https://github.com/nicklockwood/SwiftFormat/releases/download/${SWIFTFORMAT_VERSION}/swiftformat.zip" -o /tmp/swiftformat.zip
+          unzip -j -o /tmp/swiftformat.zip swiftformat -d /usr/local/bin
+          chmod +x /usr/local/bin/swiftformat
           INSTALLED=$(swiftformat --version)
-          EXPECTED="0.60.1"
-          if [ "$INSTALLED" != "$EXPECTED" ]; then
-            echo "::error::SwiftFormat version mismatch: installed $INSTALLED, expected $EXPECTED (update .pre-commit-config.yaml and ios-ci.yml together)"
+          if [ "$INSTALLED" != "$SWIFTFORMAT_VERSION" ]; then
+            echo "::error::Downloaded SwiftFormat reports version $INSTALLED, expected $SWIFTFORMAT_VERSION"
             exit 1
           fi
       - run: swiftformat --config .swiftformat --lint ios/FamilyMedicalApp/FamilyMedicalApp

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -47,14 +47,17 @@ jobs:
           # Keep in sync with .pre-commit-config.yaml SwiftFormat rev
           SWIFTFORMAT_VERSION: 0.60.1
         run: |
+          BIN_DIR="$RUNNER_TEMP/swiftformat-bin"
+          mkdir -p "$BIN_DIR"
           curl -fsSL "https://github.com/nicklockwood/SwiftFormat/releases/download/${SWIFTFORMAT_VERSION}/swiftformat.zip" -o /tmp/swiftformat.zip
-          unzip -j -o /tmp/swiftformat.zip swiftformat -d /usr/local/bin
-          chmod +x /usr/local/bin/swiftformat
-          INSTALLED=$(swiftformat --version)
+          unzip -j -o /tmp/swiftformat.zip swiftformat -d "$BIN_DIR"
+          chmod +x "$BIN_DIR/swiftformat"
+          INSTALLED=$("$BIN_DIR/swiftformat" --version)
           if [ "$INSTALLED" != "$SWIFTFORMAT_VERSION" ]; then
             echo "::error::Downloaded SwiftFormat reports version $INSTALLED, expected $SWIFTFORMAT_VERSION"
             exit 1
           fi
+          echo "$BIN_DIR" >> "$GITHUB_PATH"
       - run: swiftformat --config .swiftformat --lint ios/FamilyMedicalApp/FamilyMedicalApp
 
   xcframework:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@
 repos:
   # Swift code formatting
   - repo: https://github.com/nicklockwood/SwiftFormat
-    rev: 0.60.1  # Match CI runner version
+    rev: 0.60.1  # Read by .github/workflows/ios-ci.yml — single source of truth
     hooks:
       - id: swiftformat
         args:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,18 @@
 
 **Subagents frequently violate these rules. Read carefully.**
 
+### Day-1 Correctness
+
+- ⚠️ **ALWAYS** write code as if it were correct from day 1
+  - The final diff must look like the feature was designed this way from the start
+  - No hacks, no shims, no compatibility layers, no migration scaffolding left behind
+  - No `_deprecated` suffixes, no dual code paths, no "TODO: remove after X" markers
+  - No feature flags or conditional wiring guarding the new path against the old one
+  - When replacing code, **delete the old code** — do not leave it alongside the new
+  - When renaming, rename everywhere — do not re-export the old name for compatibility
+  - This is a pre-release project with no external consumers; there is nothing to be backwards-compatible with
+  - If a refactor is too large to land cleanly, split it into smaller PRs that are each day-1 clean — not one PR with a shim
+
 ### Environment & Execution
 
 - ⚠️ **NEVER** start processes detached

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/TestHelpers/ProviderTestHelper.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/TestHelpers/ProviderTestHelper.swift
@@ -1,0 +1,33 @@
+import Foundation
+@testable import FamilyMedicalApp
+
+/// Shared test helpers for creating Provider fixtures across test files.
+enum ProviderTestHelper {
+    /// Creates a test Provider with configurable properties.
+    ///
+    /// - Parameters:
+    ///   - name: Provider name. Defaults to "Dr. Smith".
+    ///   - organization: Optional organization. Defaults to nil.
+    ///   - specialty: Optional specialty. Defaults to "Cardiology".
+    ///   - phone: Optional phone. Defaults to "555-0100".
+    ///   - address: Optional address. Defaults to "123 Main St".
+    ///   - notes: Optional notes. Defaults to "Great doctor".
+    /// - Returns: A test Provider instance.
+    static func makeProvider(
+        name: String? = "Dr. Smith",
+        organization: String? = nil,
+        specialty: String? = "Cardiology",
+        phone: String? = "555-0100",
+        address: String? = "123 Main St",
+        notes: String? = "Great doctor"
+    ) -> Provider {
+        Provider(
+            name: name,
+            organization: organization,
+            specialty: specialty,
+            phone: phone,
+            address: address,
+            notes: notes
+        )
+    }
+}

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Auth/AccountExistsConfirmationViewTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Auth/AccountExistsConfirmationViewTests.swift
@@ -13,10 +13,12 @@ struct AccountExistsConfirmationViewTests {
         let viewModel = AuthenticationViewModel(authService: MockAuthenticationService())
         let view = AccountExistsConfirmationView(viewModel: viewModel, username: "testuser")
 
-        let sut = try view.inspect()
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
 
-        // find() throws if not found
-        _ = try sut.find(text: "Account Found")
+            // find() throws if not found
+            _ = try sut.find(text: "Account Found")
+        }
     }
 
     @Test
@@ -24,12 +26,14 @@ struct AccountExistsConfirmationViewTests {
         let viewModel = AuthenticationViewModel(authService: MockAuthenticationService())
         let view = AccountExistsConfirmationView(viewModel: viewModel, username: "myusername")
 
-        let sut = try view.inspect()
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
 
-        // find() throws if not found
-        _ = try sut.find(ViewType.Text.self) { text in
-            let string = try? text.string()
-            return string?.contains("myusername") == true
+            // find() throws if not found
+            _ = try sut.find(ViewType.Text.self) { text in
+                let string = try? text.string()
+                return string?.contains("myusername") == true
+            }
         }
     }
 
@@ -38,10 +42,12 @@ struct AccountExistsConfirmationViewTests {
         let viewModel = AuthenticationViewModel(authService: MockAuthenticationService())
         let view = AccountExistsConfirmationView(viewModel: viewModel, username: "testuser")
 
-        let sut = try view.inspect()
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
 
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityIdentifier: "confirmLoginButton")
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityIdentifier: "confirmLoginButton")
+        }
     }
 
     @Test
@@ -49,9 +55,11 @@ struct AccountExistsConfirmationViewTests {
         let viewModel = AuthenticationViewModel(authService: MockAuthenticationService())
         let view = AccountExistsConfirmationView(viewModel: viewModel, username: "testuser")
 
-        let sut = try view.inspect()
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
 
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityIdentifier: "cancelButton")
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityIdentifier: "cancelButton")
+        }
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Auth/BiometricSetupViewTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Auth/BiometricSetupViewTests.swift
@@ -14,9 +14,11 @@ struct BiometricSetupViewTests {
         let viewModel = AuthenticationViewModel()
         let view = BiometricSetupView(viewModel: viewModel, username: testUsername, passphrase: testPassphrase)
 
-        let sut = try view.inspect()
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityIdentifier: "enableBiometricButton")
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityIdentifier: "enableBiometricButton")
+        }
     }
 
     @Test
@@ -24,9 +26,11 @@ struct BiometricSetupViewTests {
         let viewModel = AuthenticationViewModel()
         let view = BiometricSetupView(viewModel: viewModel, username: testUsername, passphrase: testPassphrase)
 
-        let sut = try view.inspect()
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityIdentifier: "skipButton")
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityIdentifier: "skipButton")
+        }
     }
 
     @Test
@@ -34,9 +38,11 @@ struct BiometricSetupViewTests {
         let viewModel = AuthenticationViewModel()
         let view = BiometricSetupView(viewModel: viewModel, username: testUsername, passphrase: testPassphrase)
 
-        let sut = try view.inspect()
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityIdentifier: "backButton")
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityIdentifier: "backButton")
+        }
     }
 
     // MARK: - Button State Tests
@@ -47,10 +53,12 @@ struct BiometricSetupViewTests {
         viewModel.isLoading = false
         let view = BiometricSetupView(viewModel: viewModel, username: testUsername, passphrase: testPassphrase)
 
-        let sut = try view.inspect()
-        let button = try sut.find(viewWithAccessibilityIdentifier: "skipButton").button()
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            let button = try sut.find(viewWithAccessibilityIdentifier: "skipButton").button()
 
-        #expect(try button.isDisabled() == false)
+            #expect(try button.isDisabled() == false)
+        }
     }
 
     @Test
@@ -59,10 +67,12 @@ struct BiometricSetupViewTests {
         viewModel.isLoading = true
         let view = BiometricSetupView(viewModel: viewModel, username: testUsername, passphrase: testPassphrase)
 
-        let sut = try view.inspect()
-        let button = try sut.find(viewWithAccessibilityIdentifier: "skipButton").button()
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            let button = try sut.find(viewWithAccessibilityIdentifier: "skipButton").button()
 
-        #expect(try button.isDisabled() == true)
+            #expect(try button.isDisabled() == true)
+        }
     }
 
     // MARK: - Error Display Tests
@@ -73,9 +83,11 @@ struct BiometricSetupViewTests {
         viewModel.errorMessage = "Biometric setup failed"
         let view = BiometricSetupView(viewModel: viewModel, username: testUsername, passphrase: testPassphrase)
 
-        let sut = try view.inspect()
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityIdentifier: "errorLabel")
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityIdentifier: "errorLabel")
+        }
     }
 
     @Test
@@ -84,10 +96,12 @@ struct BiometricSetupViewTests {
         viewModel.errorMessage = nil
         let view = BiometricSetupView(viewModel: viewModel, username: testUsername, passphrase: testPassphrase)
 
-        let sut = try view.inspect()
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
 
-        #expect(throws: InspectionError.self) {
-            try sut.find(viewWithAccessibilityIdentifier: "errorLabel")
+            #expect(throws: InspectionError.self) {
+                try sut.find(viewWithAccessibilityIdentifier: "errorLabel")
+            }
         }
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Auth/PassphraseConfirmViewTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Auth/PassphraseConfirmViewTests.swift
@@ -14,9 +14,11 @@ struct PassphraseConfirmViewTests {
         let viewModel = AuthenticationViewModel()
         let view = PassphraseConfirmView(viewModel: viewModel, username: testUsername, passphrase: testPassphrase)
 
-        let sut = try view.inspect()
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityIdentifier: "confirmPassphraseField")
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityIdentifier: "confirmPassphraseField")
+        }
     }
 
     @Test
@@ -24,9 +26,11 @@ struct PassphraseConfirmViewTests {
         let viewModel = AuthenticationViewModel()
         let view = PassphraseConfirmView(viewModel: viewModel, username: testUsername, passphrase: testPassphrase)
 
-        let sut = try view.inspect()
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityIdentifier: "continueButton")
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityIdentifier: "continueButton")
+        }
     }
 
     @Test
@@ -34,9 +38,11 @@ struct PassphraseConfirmViewTests {
         let viewModel = AuthenticationViewModel()
         let view = PassphraseConfirmView(viewModel: viewModel, username: testUsername, passphrase: testPassphrase)
 
-        let sut = try view.inspect()
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityIdentifier: "backButton")
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityIdentifier: "backButton")
+        }
     }
 
     // MARK: - Button State Tests
@@ -47,10 +53,12 @@ struct PassphraseConfirmViewTests {
         viewModel.confirmPassphrase = ""
         let view = PassphraseConfirmView(viewModel: viewModel, username: testUsername, passphrase: testPassphrase)
 
-        let sut = try view.inspect()
-        let button = try sut.find(viewWithAccessibilityIdentifier: "continueButton").button()
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            let button = try sut.find(viewWithAccessibilityIdentifier: "continueButton").button()
 
-        #expect(try button.isDisabled() == true)
+            #expect(try button.isDisabled() == true)
+        }
     }
 
     @Test
@@ -59,10 +67,12 @@ struct PassphraseConfirmViewTests {
         viewModel.confirmPassphrase = "wrong-passphrase"
         let view = PassphraseConfirmView(viewModel: viewModel, username: testUsername, passphrase: testPassphrase)
 
-        let sut = try view.inspect()
-        let button = try sut.find(viewWithAccessibilityIdentifier: "continueButton").button()
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            let button = try sut.find(viewWithAccessibilityIdentifier: "continueButton").button()
 
-        #expect(try button.isDisabled() == true)
+            #expect(try button.isDisabled() == true)
+        }
     }
 
     @Test
@@ -71,10 +81,12 @@ struct PassphraseConfirmViewTests {
         viewModel.confirmPassphrase = testPassphrase
         let view = PassphraseConfirmView(viewModel: viewModel, username: testUsername, passphrase: testPassphrase)
 
-        let sut = try view.inspect()
-        let button = try sut.find(viewWithAccessibilityIdentifier: "continueButton").button()
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            let button = try sut.find(viewWithAccessibilityIdentifier: "continueButton").button()
 
-        #expect(try button.isDisabled() == false)
+            #expect(try button.isDisabled() == false)
+        }
     }
 
     // MARK: - Match/Mismatch Indicator Tests
@@ -85,9 +97,11 @@ struct PassphraseConfirmViewTests {
         viewModel.confirmPassphrase = "wrong"
         let view = PassphraseConfirmView(viewModel: viewModel, username: testUsername, passphrase: testPassphrase)
 
-        let sut = try view.inspect()
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityIdentifier: "mismatchLabel")
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityIdentifier: "mismatchLabel")
+        }
     }
 
     @Test
@@ -96,9 +110,11 @@ struct PassphraseConfirmViewTests {
         viewModel.confirmPassphrase = testPassphrase
         let view = PassphraseConfirmView(viewModel: viewModel, username: testUsername, passphrase: testPassphrase)
 
-        let sut = try view.inspect()
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityIdentifier: "matchLabel")
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityIdentifier: "matchLabel")
+        }
     }
 
     @Test
@@ -107,13 +123,15 @@ struct PassphraseConfirmViewTests {
         viewModel.confirmPassphrase = ""
         let view = PassphraseConfirmView(viewModel: viewModel, username: testUsername, passphrase: testPassphrase)
 
-        let sut = try view.inspect()
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
 
-        #expect(throws: InspectionError.self) {
-            try sut.find(viewWithAccessibilityIdentifier: "mismatchLabel")
-        }
-        #expect(throws: InspectionError.self) {
-            try sut.find(viewWithAccessibilityIdentifier: "matchLabel")
+            #expect(throws: InspectionError.self) {
+                try sut.find(viewWithAccessibilityIdentifier: "mismatchLabel")
+            }
+            #expect(throws: InspectionError.self) {
+                try sut.find(viewWithAccessibilityIdentifier: "matchLabel")
+            }
         }
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Auth/PassphraseCreationViewTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Auth/PassphraseCreationViewTests.swift
@@ -13,9 +13,11 @@ struct PassphraseCreationViewTests {
         let viewModel = AuthenticationViewModel()
         let view = PassphraseCreationView(viewModel: viewModel, username: testUsername)
 
-        let sut = try view.inspect()
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityIdentifier: "passphraseField")
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityIdentifier: "passphraseField")
+        }
     }
 
     @Test
@@ -23,9 +25,11 @@ struct PassphraseCreationViewTests {
         let viewModel = AuthenticationViewModel()
         let view = PassphraseCreationView(viewModel: viewModel, username: testUsername)
 
-        let sut = try view.inspect()
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityIdentifier: "strengthIndicator")
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityIdentifier: "strengthIndicator")
+        }
     }
 
     @Test
@@ -33,9 +37,11 @@ struct PassphraseCreationViewTests {
         let viewModel = AuthenticationViewModel()
         let view = PassphraseCreationView(viewModel: viewModel, username: testUsername)
 
-        let sut = try view.inspect()
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityIdentifier: "continueButton")
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityIdentifier: "continueButton")
+        }
     }
 
     @Test
@@ -43,9 +49,11 @@ struct PassphraseCreationViewTests {
         let viewModel = AuthenticationViewModel()
         let view = PassphraseCreationView(viewModel: viewModel, username: testUsername)
 
-        let sut = try view.inspect()
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityIdentifier: "backButton")
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityIdentifier: "backButton")
+        }
     }
 
     // MARK: - Button State Tests
@@ -56,10 +64,12 @@ struct PassphraseCreationViewTests {
         viewModel.passphrase = ""
         let view = PassphraseCreationView(viewModel: viewModel, username: testUsername)
 
-        let sut = try view.inspect()
-        let button = try sut.find(viewWithAccessibilityIdentifier: "continueButton").button()
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            let button = try sut.find(viewWithAccessibilityIdentifier: "continueButton").button()
 
-        #expect(try button.isDisabled() == true)
+            #expect(try button.isDisabled() == true)
+        }
     }
 
     @Test
@@ -68,10 +78,12 @@ struct PassphraseCreationViewTests {
         viewModel.passphrase = "short"
         let view = PassphraseCreationView(viewModel: viewModel, username: testUsername)
 
-        let sut = try view.inspect()
-        let button = try sut.find(viewWithAccessibilityIdentifier: "continueButton").button()
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            let button = try sut.find(viewWithAccessibilityIdentifier: "continueButton").button()
 
-        #expect(try button.isDisabled() == true)
+            #expect(try button.isDisabled() == true)
+        }
     }
 
     @Test
@@ -80,10 +92,12 @@ struct PassphraseCreationViewTests {
         viewModel.passphrase = "valid-test-passphrase-123"
         let view = PassphraseCreationView(viewModel: viewModel, username: testUsername)
 
-        let sut = try view.inspect()
-        let button = try sut.find(viewWithAccessibilityIdentifier: "continueButton").button()
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            let button = try sut.find(viewWithAccessibilityIdentifier: "continueButton").button()
 
-        #expect(try button.isDisabled() == false)
+            #expect(try button.isDisabled() == false)
+        }
     }
 
     // MARK: - Validation Hints Tests
@@ -94,9 +108,11 @@ struct PassphraseCreationViewTests {
         viewModel.passphrase = "weak"
         let view = PassphraseCreationView(viewModel: viewModel, username: testUsername)
 
-        let sut = try view.inspect()
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityIdentifier: "validationHints")
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityIdentifier: "validationHints")
+        }
         // Verify validation errors exist for weak passphrase
         #expect(!viewModel.passphraseValidationErrors.isEmpty)
     }
@@ -107,10 +123,12 @@ struct PassphraseCreationViewTests {
         viewModel.passphrase = ""
         let view = PassphraseCreationView(viewModel: viewModel, username: testUsername)
 
-        let sut = try view.inspect()
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
 
-        #expect(throws: InspectionError.self) {
-            try sut.find(viewWithAccessibilityIdentifier: "validationHints")
+            #expect(throws: InspectionError.self) {
+                try sut.find(viewWithAccessibilityIdentifier: "validationHints")
+            }
         }
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Auth/PassphraseEntryViewTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Auth/PassphraseEntryViewTests.swift
@@ -13,9 +13,11 @@ struct PassphraseEntryViewTests {
         let viewModel = AuthenticationViewModel()
         let view = PassphraseEntryView(viewModel: viewModel, username: testUsername)
 
-        let sut = try view.inspect()
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityIdentifier: "passphraseField")
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityIdentifier: "passphraseField")
+        }
     }
 
     @Test
@@ -23,9 +25,11 @@ struct PassphraseEntryViewTests {
         let viewModel = AuthenticationViewModel()
         let view = PassphraseEntryView(viewModel: viewModel, username: testUsername)
 
-        let sut = try view.inspect()
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityIdentifier: "continueButton")
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityIdentifier: "continueButton")
+        }
     }
 
     @Test
@@ -33,9 +37,11 @@ struct PassphraseEntryViewTests {
         let viewModel = AuthenticationViewModel()
         let view = PassphraseEntryView(viewModel: viewModel, username: testUsername)
 
-        let sut = try view.inspect()
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityIdentifier: "backButton")
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityIdentifier: "backButton")
+        }
     }
 
     // MARK: - Button State Tests
@@ -46,10 +52,12 @@ struct PassphraseEntryViewTests {
         viewModel.passphrase = ""
         let view = PassphraseEntryView(viewModel: viewModel, username: testUsername)
 
-        let sut = try view.inspect()
-        let button = try sut.find(viewWithAccessibilityIdentifier: "continueButton").button()
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            let button = try sut.find(viewWithAccessibilityIdentifier: "continueButton").button()
 
-        #expect(try button.isDisabled() == true)
+            #expect(try button.isDisabled() == true)
+        }
     }
 
     @Test
@@ -58,10 +66,12 @@ struct PassphraseEntryViewTests {
         viewModel.passphrase = "any-passphrase"
         let view = PassphraseEntryView(viewModel: viewModel, username: testUsername)
 
-        let sut = try view.inspect()
-        let button = try sut.find(viewWithAccessibilityIdentifier: "continueButton").button()
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            let button = try sut.find(viewWithAccessibilityIdentifier: "continueButton").button()
 
-        #expect(try button.isDisabled() == false)
+            #expect(try button.isDisabled() == false)
+        }
     }
 
     // MARK: - Error Display Tests
@@ -72,9 +82,11 @@ struct PassphraseEntryViewTests {
         viewModel.errorMessage = "Invalid passphrase"
         let view = PassphraseEntryView(viewModel: viewModel, username: testUsername)
 
-        let sut = try view.inspect()
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityIdentifier: "errorLabel")
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityIdentifier: "errorLabel")
+        }
     }
 
     @Test
@@ -83,10 +95,12 @@ struct PassphraseEntryViewTests {
         viewModel.errorMessage = nil
         let view = PassphraseEntryView(viewModel: viewModel, username: testUsername)
 
-        let sut = try view.inspect()
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
 
-        #expect(throws: InspectionError.self) {
-            try sut.find(viewWithAccessibilityIdentifier: "errorLabel")
+            #expect(throws: InspectionError.self) {
+                try sut.find(viewWithAccessibilityIdentifier: "errorLabel")
+            }
         }
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Auth/UsernameEntryViewTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Auth/UsernameEntryViewTests.swift
@@ -11,9 +11,11 @@ struct UsernameEntryViewTests {
         let viewModel = AuthenticationViewModel()
         let view = UsernameEntryView(viewModel: viewModel, isNewUser: true)
 
-        let sut = try view.inspect()
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityIdentifier: "usernameField")
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityIdentifier: "usernameField")
+        }
     }
 
     @Test
@@ -21,9 +23,11 @@ struct UsernameEntryViewTests {
         let viewModel = AuthenticationViewModel()
         let view = UsernameEntryView(viewModel: viewModel, isNewUser: true)
 
-        let sut = try view.inspect()
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityIdentifier: "continueButton")
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityIdentifier: "continueButton")
+        }
     }
 
     @Test
@@ -31,9 +35,11 @@ struct UsernameEntryViewTests {
         let viewModel = AuthenticationViewModel()
         let view = UsernameEntryView(viewModel: viewModel, isNewUser: true)
 
-        let sut = try view.inspect()
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityIdentifier: "backButton")
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityIdentifier: "backButton")
+        }
     }
 
     // MARK: - Button State Tests
@@ -44,10 +50,12 @@ struct UsernameEntryViewTests {
         viewModel.username = "ab" // Too short
         let view = UsernameEntryView(viewModel: viewModel, isNewUser: true)
 
-        let sut = try view.inspect()
-        let button = try sut.find(viewWithAccessibilityIdentifier: "continueButton").button()
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            let button = try sut.find(viewWithAccessibilityIdentifier: "continueButton").button()
 
-        #expect(try button.isDisabled() == true)
+            #expect(try button.isDisabled() == true)
+        }
     }
 
     @Test
@@ -56,10 +64,12 @@ struct UsernameEntryViewTests {
         viewModel.username = "testuser"
         let view = UsernameEntryView(viewModel: viewModel, isNewUser: true)
 
-        let sut = try view.inspect()
-        let button = try sut.find(viewWithAccessibilityIdentifier: "continueButton").button()
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            let button = try sut.find(viewWithAccessibilityIdentifier: "continueButton").button()
 
-        #expect(try button.isDisabled() == false)
+            #expect(try button.isDisabled() == false)
+        }
     }
 
     // MARK: - Error Display Tests
@@ -70,9 +80,11 @@ struct UsernameEntryViewTests {
         viewModel.errorMessage = "Test error"
         let view = UsernameEntryView(viewModel: viewModel, isNewUser: true)
 
-        let sut = try view.inspect()
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityIdentifier: "errorLabel")
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityIdentifier: "errorLabel")
+        }
     }
 
     @Test
@@ -81,10 +93,12 @@ struct UsernameEntryViewTests {
         viewModel.errorMessage = nil
         let view = UsernameEntryView(viewModel: viewModel, isNewUser: true)
 
-        let sut = try view.inspect()
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
 
-        #expect(throws: InspectionError.self) {
-            try sut.find(viewWithAccessibilityIdentifier: "errorLabel")
+            #expect(throws: InspectionError.self) {
+                try sut.find(viewWithAccessibilityIdentifier: "errorLabel")
+            }
         }
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Auth/WelcomeViewTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Auth/WelcomeViewTests.swift
@@ -11,10 +11,12 @@ struct WelcomeViewTests {
         let viewModel = AuthenticationViewModel()
         let view = WelcomeView(viewModel: viewModel)
 
-        let sut = try view.inspect()
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
 
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityLabel: "Family Medical App icon")
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityLabel: "Family Medical App icon")
+        }
     }
 
     @Test
@@ -22,9 +24,11 @@ struct WelcomeViewTests {
         let viewModel = AuthenticationViewModel()
         let view = WelcomeView(viewModel: viewModel)
 
-        let sut = try view.inspect()
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityIdentifier: "createAccountButton")
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityIdentifier: "createAccountButton")
+        }
     }
 
     @Test
@@ -32,8 +36,10 @@ struct WelcomeViewTests {
         let viewModel = AuthenticationViewModel()
         let view = WelcomeView(viewModel: viewModel)
 
-        let sut = try view.inspect()
-        // find() throws if not found
-        _ = try sut.find(viewWithAccessibilityIdentifier: "signInButton")
+        try HostedInspection.inspect(view) { view in
+            let sut = try view.inspect()
+            // find() throws if not found
+            _ = try sut.find(viewWithAccessibilityIdentifier: "signInButton")
+        }
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Documents/DocumentPickerViewTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Documents/DocumentPickerViewTests.swift
@@ -39,8 +39,10 @@ struct DocumentPickerViewTests {
         let viewModel = makeViewModel()
         let view = DocumentPickerView(viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.VStack.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.VStack.self)
+        }
     }
 
     @Test
@@ -49,8 +51,10 @@ struct DocumentPickerViewTests {
         let viewModel = makeViewModel(existing: [document])
         let view = DocumentPickerView(viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.LazyVGrid.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.LazyVGrid.self)
+        }
     }
 
     @Test
@@ -58,8 +62,10 @@ struct DocumentPickerViewTests {
         let viewModel = makeViewModel()
         let view = DocumentPickerView(viewModel: viewModel)
 
-        let text = try view.inspect().find(text: viewModel.countSummary)
-        #expect(try text.string() == viewModel.countSummary)
+        try HostedInspection.inspect(view) { view in
+            let text = try view.inspect().find(text: viewModel.countSummary)
+            #expect(try text.string() == viewModel.countSummary)
+        }
     }
 
     @Test
@@ -68,8 +74,10 @@ struct DocumentPickerViewTests {
         let view = DocumentPickerView(viewModel: viewModel)
 
         #expect(viewModel.canAddMore)
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.Menu.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.Menu.self)
+        }
     }
 
     @Test
@@ -82,9 +90,11 @@ struct DocumentPickerViewTests {
         let view = DocumentPickerView(viewModel: viewModel)
 
         #expect(!viewModel.canAddMore)
-        let inspected = try view.inspect()
-        #expect(throws: (any Error).self) {
-            _ = try inspected.find(ViewType.Menu.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            #expect(throws: (any Error).self) {
+                _ = try inspected.find(ViewType.Menu.self)
+            }
         }
     }
 
@@ -96,9 +106,11 @@ struct DocumentPickerViewTests {
         viewModel.errorMessage = "Test error message"
 
         let view = DocumentPickerView(viewModel: viewModel)
-        let inspected = try view.inspect()
-        let errorText = try inspected.find(text: "Test error message")
-        #expect(try errorText.string() == "Test error message")
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let errorText = try inspected.find(text: "Test error message")
+            #expect(try errorText.string() == "Test error message")
+        }
     }
 
     @Test
@@ -107,10 +119,12 @@ struct DocumentPickerViewTests {
         viewModel.errorMessage = nil
         let view = DocumentPickerView(viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        #expect(throws: (any Error).self) {
-            _ = try inspected.find(ViewType.Text.self) { text in
-                try text.string().contains("error")
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            #expect(throws: (any Error).self) {
+                _ = try inspected.find(ViewType.Text.self) { text in
+                    try text.string().contains("error")
+                }
             }
         }
     }
@@ -123,8 +137,10 @@ struct DocumentPickerViewTests {
         viewModel.isLoading = true
 
         let view = DocumentPickerView(viewModel: viewModel)
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.ProgressView.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.ProgressView.self)
+        }
     }
 
     @Test
@@ -133,9 +149,11 @@ struct DocumentPickerViewTests {
         viewModel.isLoading = false
 
         let view = DocumentPickerView(viewModel: viewModel)
-        let inspected = try view.inspect()
-        #expect(throws: (any Error).self) {
-            _ = try inspected.find(ViewType.ProgressView.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            #expect(throws: (any Error).self) {
+                _ = try inspected.find(ViewType.ProgressView.self)
+            }
         }
     }
 
@@ -150,8 +168,10 @@ struct DocumentPickerViewTests {
         ])
         let view = DocumentPickerView(viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.LazyVGrid.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.LazyVGrid.self)
+        }
         #expect(viewModel.drafts.count == 3)
     }
 
@@ -162,8 +182,10 @@ struct DocumentPickerViewTests {
         let viewModel = makeViewModel()
         let view = DocumentPickerView(viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.Menu.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.Menu.self)
+        }
     }
 
     @Test
@@ -175,9 +197,11 @@ struct DocumentPickerViewTests {
         let viewModel = makeViewModel(existing: documents)
         let view = DocumentPickerView(viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        #expect(throws: (any Error).self) {
-            _ = try inspected.find(ViewType.Menu.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            #expect(throws: (any Error).self) {
+                _ = try inspected.find(ViewType.Menu.self)
+            }
         }
     }
 
@@ -190,8 +214,10 @@ struct DocumentPickerViewTests {
         ])
         let view = DocumentPickerView(viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.LazyVGrid.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.LazyVGrid.self)
+        }
     }
 
     @Test
@@ -199,8 +225,10 @@ struct DocumentPickerViewTests {
         let viewModel = makeViewModel(existing: [])
         let view = DocumentPickerView(viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.LazyVGrid.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.LazyVGrid.self)
+        }
         #expect(viewModel.drafts.isEmpty)
     }
 
@@ -237,10 +265,12 @@ struct DocumentPickerViewTests {
         let viewModel = makeViewModel()
         let view = DocumentPickerView(viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        let menu = try inspected.find(ViewType.Menu.self)
-        let buttons = menu.findAll(ViewType.Button.self)
-        #expect(buttons.count >= 2)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let menu = try inspected.find(ViewType.Menu.self)
+            let buttons = menu.findAll(ViewType.Button.self)
+            #expect(buttons.count >= 2)
+        }
     }
 
     @Test
@@ -248,11 +278,13 @@ struct DocumentPickerViewTests {
         let viewModel = makeViewModel()
         let view = DocumentPickerView(viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        let menu = try inspected.find(ViewType.Menu.self)
-        _ = try menu.find(ViewType.Label.self) { label in
-            let systemImage = try? label.find(ViewType.Image.self)
-            return systemImage != nil
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let menu = try inspected.find(ViewType.Menu.self)
+            _ = try menu.find(ViewType.Label.self) { label in
+                let systemImage = try? label.find(ViewType.Image.self)
+                return systemImage != nil
+            }
         }
     }
 
@@ -264,10 +296,12 @@ struct DocumentPickerViewTests {
         ])
         let view = DocumentPickerView(viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        let grid = try inspected.find(ViewType.LazyVGrid.self)
-        let thumbnails = grid.findAll(DocumentThumbnailView.self)
-        #expect(thumbnails.count == 2)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let grid = try inspected.find(ViewType.LazyVGrid.self)
+            let thumbnails = grid.findAll(DocumentThumbnailView.self)
+            #expect(thumbnails.count == 2)
+        }
     }
 
     @Test
@@ -275,10 +309,12 @@ struct DocumentPickerViewTests {
         let viewModel = makeViewModel()
         let view = DocumentPickerView(viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        let vstack = try inspected.find(ViewType.VStack.self)
-        let label = try vstack.accessibilityLabel().string()
-        #expect(label == "Attachments")
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let vstack = try inspected.find(ViewType.VStack.self)
+            let label = try vstack.accessibilityLabel().string()
+            #expect(label == "Attachments")
+        }
     }
 
     @Test
@@ -286,10 +322,12 @@ struct DocumentPickerViewTests {
         let viewModel = makeViewModel()
         let view = DocumentPickerView(viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        let grid = try inspected.find(ViewType.LazyVGrid.self)
-        #expect(throws: Never.self) {
-            _ = try grid.find(ViewType.Menu.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let grid = try inspected.find(ViewType.LazyVGrid.self)
+            #expect(throws: Never.self) {
+                _ = try grid.find(ViewType.Menu.self)
+            }
         }
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Documents/DocumentThumbnailViewTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Documents/DocumentThumbnailViewTests.swift
@@ -44,8 +44,10 @@ struct DocumentThumbnailViewTests {
             onRemove: nil
         )
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.ZStack.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.ZStack.self)
+        }
     }
 
     @Test
@@ -59,9 +61,11 @@ struct DocumentThumbnailViewTests {
             onRemove: nil
         )
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.ZStack.self)
-        _ = try inspected.find(ViewType.Image.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.ZStack.self)
+            _ = try inspected.find(ViewType.Image.self)
+        }
     }
 
     @Test
@@ -74,8 +78,10 @@ struct DocumentThumbnailViewTests {
             size: 100
         )
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.ZStack.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.ZStack.self)
+        }
     }
 
     // MARK: - MIME Type Icon Tests
@@ -89,9 +95,11 @@ struct DocumentThumbnailViewTests {
             onRemove: nil
         )
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.Image.self)
-        _ = try inspected.find(text: "JPG")
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.Image.self)
+            _ = try inspected.find(text: "JPG")
+        }
     }
 
     @Test
@@ -103,9 +111,11 @@ struct DocumentThumbnailViewTests {
             onRemove: nil
         )
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.Image.self)
-        _ = try inspected.find(text: "PNG")
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.Image.self)
+            _ = try inspected.find(text: "PNG")
+        }
     }
 
     @Test
@@ -117,9 +127,11 @@ struct DocumentThumbnailViewTests {
             onRemove: nil
         )
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.Image.self)
-        _ = try inspected.find(text: "PDF")
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.Image.self)
+            _ = try inspected.find(text: "PDF")
+        }
     }
 
     // MARK: - Callback Tests
@@ -135,8 +147,10 @@ struct DocumentThumbnailViewTests {
             onRemove: nil
         )
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.ZStack.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.ZStack.self)
+        }
         #expect(!tapped)
     }
 
@@ -151,9 +165,11 @@ struct DocumentThumbnailViewTests {
             onRemove: { removed = true }
         )
 
-        let inspected = try view.inspect()
-        let buttons = inspected.findAll(ViewType.Button.self)
-        #expect(buttons.count == 1)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let buttons = inspected.findAll(ViewType.Button.self)
+            #expect(buttons.count == 1)
+        }
         #expect(!removed)
     }
 
@@ -169,9 +185,11 @@ struct DocumentThumbnailViewTests {
             onRemove: { removed = true }
         )
 
-        let inspected = try view.inspect()
-        let buttons = inspected.findAll(ViewType.Button.self)
-        #expect(buttons.count == 1)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let buttons = inspected.findAll(ViewType.Button.self)
+            #expect(buttons.count == 1)
+        }
         #expect(!tapped)
         #expect(!removed)
     }
@@ -187,9 +205,11 @@ struct DocumentThumbnailViewTests {
             onRemove: {}
         )
 
-        let inspected = try view.inspect()
-        let buttons = inspected.findAll(ViewType.Button.self)
-        #expect(buttons.count == 1)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let buttons = inspected.findAll(ViewType.Button.self)
+            #expect(buttons.count == 1)
+        }
     }
 
     @Test
@@ -201,9 +221,11 @@ struct DocumentThumbnailViewTests {
             onRemove: nil
         )
 
-        let inspected = try view.inspect()
-        let buttons = inspected.findAll(ViewType.Button.self)
-        #expect(buttons.isEmpty)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let buttons = inspected.findAll(ViewType.Button.self)
+            #expect(buttons.isEmpty)
+        }
     }
 
     // MARK: - Thumbnail Content Tests
@@ -223,8 +245,10 @@ struct DocumentThumbnailViewTests {
             onRemove: nil
         )
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.Image.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.Image.self)
+        }
     }
 
     @Test
@@ -241,9 +265,11 @@ struct DocumentThumbnailViewTests {
             onRemove: nil
         )
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.Image.self)
-        _ = try inspected.find(text: "JPG")
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.Image.self)
+            _ = try inspected.find(text: "JPG")
+        }
     }
 
     @Test
@@ -260,8 +286,10 @@ struct DocumentThumbnailViewTests {
             onRemove: nil
         )
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.Image.self)
-        _ = try inspected.find(text: "PDF")
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.Image.self)
+            _ = try inspected.find(text: "PDF")
+        }
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Documents/DocumentViewerViewTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Documents/DocumentViewerViewTests.swift
@@ -45,8 +45,10 @@ struct DocumentViewerViewTests {
         let viewModel = makeViewModel()
         let view = DocumentViewerView(viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.NavigationStack.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.NavigationStack.self)
+        }
     }
 
     @Test
@@ -54,8 +56,10 @@ struct DocumentViewerViewTests {
         let viewModel = makeViewModel(mimeType: "image/jpeg")
         let view = DocumentViewerView(viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.NavigationStack.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.NavigationStack.self)
+        }
         #expect(viewModel.isImage)
     }
 
@@ -64,8 +68,10 @@ struct DocumentViewerViewTests {
         let viewModel = makeViewModel(title: "document.pdf", mimeType: "application/pdf")
         let view = DocumentViewerView(viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.NavigationStack.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.NavigationStack.self)
+        }
         #expect(viewModel.isPDF)
     }
 
@@ -77,8 +83,10 @@ struct DocumentViewerViewTests {
         viewModel.isLoading = true
 
         let view = DocumentViewerView(viewModel: viewModel)
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.ProgressView.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.ProgressView.self)
+        }
     }
 
     @Test
@@ -87,8 +95,10 @@ struct DocumentViewerViewTests {
         viewModel.errorMessage = "Failed to load content"
 
         let view = DocumentViewerView(viewModel: viewModel)
-        let inspected = try view.inspect()
-        _ = try inspected.find(text: "Failed to load content")
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(text: "Failed to load content")
+        }
     }
 
     // MARK: - Content Display Tests
@@ -99,8 +109,10 @@ struct DocumentViewerViewTests {
         await viewModel.loadContent()
 
         let view = DocumentViewerView(viewModel: viewModel)
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.NavigationStack.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.NavigationStack.self)
+        }
         #expect(viewModel.hasContent)
     }
 
@@ -109,8 +121,10 @@ struct DocumentViewerViewTests {
         let viewModel = makeViewModel(title: "medical_report.jpg")
         let view = DocumentViewerView(viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.NavigationStack.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.NavigationStack.self)
+        }
         #expect(viewModel.displayFileName == "medical_report.jpg")
     }
 
@@ -119,8 +133,10 @@ struct DocumentViewerViewTests {
         let viewModel = makeViewModel()
         let view = DocumentViewerView(viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.NavigationStack.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.NavigationStack.self)
+        }
         #expect(!viewModel.displayFileSize.isEmpty)
     }
 
@@ -131,8 +147,10 @@ struct DocumentViewerViewTests {
         let viewModel = makeViewModel(mimeType: "image/jpeg")
         let view = DocumentViewerView(viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.NavigationStack.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.NavigationStack.self)
+        }
         #expect(viewModel.isImage)
     }
 
@@ -143,8 +161,10 @@ struct DocumentViewerViewTests {
         let viewModel = makeViewModel(title: "doc.pdf", mimeType: "application/pdf")
         let view = DocumentViewerView(viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.NavigationStack.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.NavigationStack.self)
+        }
         #expect(viewModel.isPDF)
         #expect(!viewModel.isImage)
     }
@@ -157,8 +177,10 @@ struct DocumentViewerViewTests {
         viewModel.showingExportWarning = true
 
         let view = DocumentViewerView(viewModel: viewModel)
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.NavigationStack.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.NavigationStack.self)
+        }
     }
 
     // MARK: - Share Sheet Tests
@@ -169,7 +191,9 @@ struct DocumentViewerViewTests {
         viewModel.showingShareSheet = true
 
         let view = DocumentViewerView(viewModel: viewModel)
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.NavigationStack.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.NavigationStack.self)
+        }
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Documents/ExportWarningDialogTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Documents/ExportWarningDialogTests.swift
@@ -24,8 +24,10 @@ struct ExportWarningDialogTests {
             )
 
         // Use find() for deterministic coverage
-        let inspected = try content.inspect()
-        _ = try inspected.find(text: "Test Content")
+        try HostedInspection.inspect(content) { content in
+            let inspected = try content.inspect()
+            _ = try inspected.find(text: "Test Content")
+        }
 
         #expect(!wasConfirmed)
         #expect(!wasCancelled)
@@ -46,8 +48,10 @@ struct ExportWarningDialogTests {
             )
 
         // Use find() for deterministic coverage
-        let inspected = try content.inspect()
-        _ = try inspected.find(text: "Main Content")
+        try HostedInspection.inspect(content) { content in
+            let inspected = try content.inspect()
+            _ = try inspected.find(text: "Main Content")
+        }
     }
 
     @Test
@@ -65,8 +69,10 @@ struct ExportWarningDialogTests {
             )
 
         // Use find() for deterministic coverage
-        let inspected = try content.inspect()
-        _ = try inspected.find(text: "Main Content")
+        try HostedInspection.inspect(content) { content in
+            let inspected = try content.inspect()
+            _ = try inspected.find(text: "Main Content")
+        }
     }
 
     // MARK: - Default Cancel Callback Tests
@@ -85,8 +91,10 @@ struct ExportWarningDialogTests {
             ) {}
 
         // Use find() for deterministic coverage
-        let inspected = try content.inspect()
-        _ = try inspected.find(text: "Content")
+        try HostedInspection.inspect(content) { content in
+            let inspected = try content.inspect()
+            _ = try inspected.find(text: "Content")
+        }
     }
 
     // MARK: - Callback Invocation Tests
@@ -101,8 +109,10 @@ struct ExportWarningDialogTests {
             ) { wasConfirmed = true }
 
         // Use find() for deterministic coverage
-        let inspected = try content.inspect()
-        _ = try inspected.find(text: "Content")
+        try HostedInspection.inspect(content) { content in
+            let inspected = try content.inspect()
+            _ = try inspected.find(text: "Content")
+        }
         // Callback is stored but not invoked until user taps Export
         #expect(!wasConfirmed)
     }
@@ -119,8 +129,10 @@ struct ExportWarningDialogTests {
             )
 
         // Use find() for deterministic coverage
-        let inspected = try content.inspect()
-        _ = try inspected.find(text: "Content")
+        try HostedInspection.inspect(content) { content in
+            let inspected = try content.inspect()
+            _ = try inspected.find(text: "Content")
+        }
         // Callback is stored but not invoked until user taps Cancel
         #expect(!wasCancelled)
     }
@@ -142,8 +154,10 @@ struct ExportWarningDialogTests {
         ) {}
 
         // Use find() for deterministic coverage
-        let inspected = try content.inspect()
-        _ = try inspected.find(ViewType.Button.self)
+        try HostedInspection.inspect(content) { content in
+            let inspected = try content.inspect()
+            _ = try inspected.find(ViewType.Button.self)
+        }
     }
 
     @Test
@@ -154,8 +168,10 @@ struct ExportWarningDialogTests {
             ) {}
 
         // Use find() for deterministic coverage
-        let inspected = try content.inspect()
-        _ = try inspected.find(ViewType.Image.self)
+        try HostedInspection.inspect(content) { content in
+            let inspected = try content.inspect()
+            _ = try inspected.find(ViewType.Image.self)
+        }
     }
 
     @Test
@@ -169,9 +185,11 @@ struct ExportWarningDialogTests {
         ) {}
 
         // Use find() for deterministic coverage
-        let inspected = try content.inspect()
-        _ = try inspected.find(text: "Header")
-        _ = try inspected.find(text: "Body")
+        try HostedInspection.inspect(content) { content in
+            let inspected = try content.inspect()
+            _ = try inspected.find(text: "Header")
+            _ = try inspected.find(text: "Body")
+        }
     }
 
     // MARK: - State Management Tests
@@ -191,8 +209,10 @@ struct ExportWarningDialogTests {
             ) {}
 
         // Use find() for deterministic coverage
-        let inspected = try content.inspect()
-        _ = try inspected.find(text: "Content")
+        try HostedInspection.inspect(content) { content in
+            let inspected = try content.inspect()
+            _ = try inspected.find(text: "Content")
+        }
 
         // Simulate showing dialog
         isPresented = true

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Home/AddPersonViewTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Home/AddPersonViewTests.swift
@@ -36,8 +36,10 @@ struct AddPersonViewTests {
         let view = AddPersonView(viewModel: viewModel)
 
         // Use find() for deterministic coverage
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.NavigationStack.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.NavigationStack.self)
+        }
     }
 
     @Test
@@ -45,9 +47,11 @@ struct AddPersonViewTests {
         let viewModel = createViewModel()
         let view = AddPersonView(viewModel: viewModel)
 
-        let navStack = try view.inspect().navigationStack()
-        let form = try navStack.form(0)
-        _ = form
+        try HostedInspection.inspect(view) { view in
+            let navStack = try view.inspect().navigationStack()
+            let form = try navStack.form(0)
+            _ = form
+        }
     }
 
     @Test
@@ -55,10 +59,12 @@ struct AddPersonViewTests {
         let viewModel = createViewModel()
         let view = AddPersonView(viewModel: viewModel)
 
-        let navStack = try view.inspect().navigationStack()
-        let form = try navStack.form(0)
-        // Verify form has sections
-        _ = try form.section(0)
+        try HostedInspection.inspect(view) { view in
+            let navStack = try view.inspect().navigationStack()
+            let form = try navStack.form(0)
+            // Verify form has sections
+            _ = try form.section(0)
+        }
     }
 
     @Test
@@ -74,8 +80,10 @@ struct AddPersonViewTests {
 
         let view = AddPersonView(viewModel: viewModel)
         // Error state still renders the Form structure
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.Form.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.Form.self)
+        }
     }
 
     @Test
@@ -85,7 +93,9 @@ struct AddPersonViewTests {
 
         let view = AddPersonView(viewModel: viewModel)
         // Loading state still renders the Form structure
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.Form.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.Form.self)
+        }
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Home/EmptyMembersViewTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Home/EmptyMembersViewTests.swift
@@ -15,7 +15,9 @@ struct EmptyMembersViewTests {
         }
 
         // View should render without crashing
-        _ = try view.inspect()
+        try HostedInspection.inspect(view) { view in
+            _ = try view.inspect()
+        }
         #expect(tapped == false) // Not tapped yet
     }
 
@@ -28,9 +30,11 @@ struct EmptyMembersViewTests {
             tapped = true
         }
 
-        let contentView = try view.inspect().contentUnavailableView()
-        let button = try contentView.find(button: "Add Member")
-        try button.tap()
+        try HostedInspection.inspect(view) { view in
+            let contentView = try view.inspect().contentUnavailableView()
+            let button = try contentView.find(button: "Add Member")
+            try button.tap()
+        }
 
         #expect(tapped == true)
     }
@@ -38,9 +42,11 @@ struct EmptyMembersViewTests {
     @Test
     func buttonIsRendered() throws {
         let view = EmptyMembersView {}
-        let contentView = try view.inspect().contentUnavailableView()
-        let button = try contentView.find(button: "Add Member")
-        let buttonText = try button.labelView().text().string()
-        #expect(buttonText == "Add Member")
+        try HostedInspection.inspect(view) { view in
+            let contentView = try view.inspect().contentUnavailableView()
+            let button = try contentView.find(button: "Add Member")
+            let buttonText = try button.labelView().text().string()
+            #expect(buttonText == "Add Member")
+        }
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Home/HomeViewTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Home/HomeViewTests.swift
@@ -31,8 +31,10 @@ struct HomeViewTests {
         let view = HomeView(viewModel: viewModel)
 
         // Use find() for deterministic coverage - verify Group renders
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.Group.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.Group.self)
+        }
     }
 
     @Test
@@ -41,8 +43,10 @@ struct HomeViewTests {
         let view = HomeView(viewModel: viewModel)
 
         // Empty state shows EmptyMembersView
-        let inspected = try view.inspect()
-        _ = try inspected.find(EmptyMembersView.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(EmptyMembersView.self)
+        }
     }
 
     @Test
@@ -61,8 +65,10 @@ struct HomeViewTests {
 
         let view = HomeView(viewModel: viewModel)
         // With persons, should show List
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.List.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.List.self)
+        }
     }
 
     // MARK: - Error State Tests
@@ -80,8 +86,10 @@ struct HomeViewTests {
 
         let view = HomeView(viewModel: viewModel)
         // Error state still renders the Group (alert is separate)
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.Group.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.Group.self)
+        }
     }
 
     // MARK: - Loading State Tests
@@ -93,8 +101,10 @@ struct HomeViewTests {
 
         let view = HomeView(viewModel: viewModel)
         // Loading state shows ProgressView overlay
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.ProgressView.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.ProgressView.self)
+        }
     }
 
     // MARK: - Delete Tests

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Home/PersonDetailViewTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Home/PersonDetailViewTests.swift
@@ -40,9 +40,11 @@ struct PersonDetailViewTests {
         let viewModel = createViewModel(person: person)
         let view = PersonDetailView(person: person, viewModel: viewModel)
 
-        let inspectedView = try view.inspect()
-        // Verify the root Group exists
-        _ = try inspectedView.group()
+        try HostedInspection.inspect(view) { view in
+            let inspectedView = try view.inspect()
+            // Verify the root Group exists
+            _ = try inspectedView.group()
+        }
     }
 
     @Test
@@ -52,8 +54,10 @@ struct PersonDetailViewTests {
         let view = PersonDetailView(person: person, viewModel: viewModel)
 
         // Use find() for deterministic coverage
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.Group.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.Group.self)
+        }
     }
 
     @Test
@@ -80,9 +84,11 @@ struct PersonDetailViewTests {
 
         let view = PersonDetailView(person: person, viewModel: viewModel)
 
-        let inspectedView = try view.inspect()
-        // Find ProgressView within the view hierarchy
-        _ = try inspectedView.find(ViewType.ProgressView.self)
+        try HostedInspection.inspect(view) { view in
+            let inspectedView = try view.inspect()
+            // Find ProgressView within the view hierarchy
+            _ = try inspectedView.find(ViewType.ProgressView.self)
+        }
     }
 
     @Test
@@ -107,8 +113,10 @@ struct PersonDetailViewTests {
 
         let view = PersonDetailView(person: person, viewModel: viewModel)
         // Error state still renders the Group structure
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.Group.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.Group.self)
+        }
     }
 
     @Test
@@ -145,12 +153,14 @@ struct PersonDetailViewTests {
         await viewModel.loadRecordCounts()
 
         let view = PersonDetailView(person: person, viewModel: viewModel)
-        let inspectedView = try view.inspect()
-        // Find List within the view hierarchy
-        let list = try inspectedView.find(ViewType.List.self)
-        // Record types are in section 1 (section 0 is "My Providers")
-        let recordTypesSection = try list.section(1)
-        _ = try recordTypesSection.forEach(0)
+        try HostedInspection.inspect(view) { view in
+            let inspectedView = try view.inspect()
+            // Find List within the view hierarchy
+            let list = try inspectedView.find(ViewType.List.self)
+            // Record types are in section 1 (section 0 is "My Providers")
+            let recordTypesSection = try list.section(1)
+            _ = try recordTypesSection.forEach(0)
+        }
     }
 
     @Test
@@ -161,14 +171,16 @@ struct PersonDetailViewTests {
         await viewModel.loadRecordCounts()
 
         let view = PersonDetailView(person: person, viewModel: viewModel)
-        let inspectedView = try view.inspect()
-        // Find List within the view hierarchy
-        let list = try inspectedView.find(ViewType.List.self)
-        // Record types are in section 1 (section 0 is "My Providers")
-        let forEach = try list.section(1).forEach(0)
+        try HostedInspection.inspect(view) { view in
+            let inspectedView = try view.inspect()
+            // Find List within the view hierarchy
+            let list = try inspectedView.find(ViewType.List.self)
+            // Record types are in section 1 (section 0 is "My Providers")
+            let forEach = try list.section(1).forEach(0)
 
-        // Verify NavigationLink exists for first item
-        _ = try forEach.navigationLink(0)
+            // Verify NavigationLink exists for first item
+            _ = try forEach.navigationLink(0)
+        }
     }
 
     @Test
@@ -177,10 +189,12 @@ struct PersonDetailViewTests {
 
         // Initialize without providing viewModel to test default initialization
         let view = PersonDetailView(person: person)
-        let inspectedView = try view.inspect()
+        try HostedInspection.inspect(view) { view in
+            let inspectedView = try view.inspect()
 
-        // Verify view renders successfully with default viewModel
-        _ = try inspectedView.group()
+            // Verify view renders successfully with default viewModel
+            _ = try inspectedView.group()
+        }
     }
 
     @Test
@@ -193,8 +207,10 @@ struct PersonDetailViewTests {
 
         let view = PersonDetailView(person: person, viewModel: viewModel)
         // View should still render when error is present
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.Group.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.Group.self)
+        }
 
         // Verify error message is set
         #expect(viewModel.errorMessage == "Test error")
@@ -239,16 +255,18 @@ struct PersonDetailViewTests {
         await viewModel.loadRecordCounts()
 
         let view = PersonDetailView(person: person, viewModel: viewModel)
-        let inspectedView = try view.inspect()
-        // Find List within the view hierarchy
-        let list = try inspectedView.find(ViewType.List.self)
-        // Record types are in section 1 (section 0 is "My Providers")
-        let forEach = try list.section(1).forEach(0)
+        try HostedInspection.inspect(view) { view in
+            let inspectedView = try view.inspect()
+            // Find List within the view hierarchy
+            let list = try inspectedView.find(ViewType.List.self)
+            // Record types are in section 1 (section 0 is "My Providers")
+            let forEach = try list.section(1).forEach(0)
 
-        // Verify each record type appears in the list
-        // There should be entries for all RecordType cases
-        for index in 0 ..< RecordType.allCases.count {
-            _ = try forEach.navigationLink(index)
+            // Verify each record type appears in the list
+            // There should be entries for all RecordType cases
+            for index in 0 ..< RecordType.allCases.count {
+                _ = try forEach.navigationLink(index)
+            }
         }
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Home/PersonRowViewTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Home/PersonRowViewTests.swift
@@ -22,9 +22,11 @@ struct PersonRowViewTests {
         let person = try createTestPerson(name: "Alice Smith")
         let view = PersonRowView(person: person)
 
-        let vStack = try view.inspect().vStack()
-        let nameText = try vStack.text(0)
-        #expect(try nameText.string() == "Alice Smith")
+        try HostedInspection.inspect(view) { view in
+            let vStack = try view.inspect().vStack()
+            let nameText = try vStack.text(0)
+            #expect(try nameText.string() == "Alice Smith")
+        }
     }
 
     @Test
@@ -32,9 +34,11 @@ struct PersonRowViewTests {
         let person = try createTestPerson(labels: ["Self", "Parent"])
         let view = PersonRowView(person: person)
 
-        let vStack = try view.inspect().vStack()
-        let labelsText = try vStack.text(1)
-        #expect(try labelsText.string() == "Self, Parent")
+        try HostedInspection.inspect(view) { view in
+            let vStack = try view.inspect().vStack()
+            let labelsText = try vStack.text(1)
+            #expect(try labelsText.string() == "Self, Parent")
+        }
     }
 
     @Test
@@ -43,8 +47,10 @@ struct PersonRowViewTests {
         let person = try createTestPerson(dateOfBirth: dob)
         let view = PersonRowView(person: person)
 
-        _ = try view.inspect().vStack()
-        // DOB is displayed, verification that view renders without error
+        try HostedInspection.inspect(view) { view in
+            _ = try view.inspect().vStack()
+            // DOB is displayed, verification that view renders without error
+        }
     }
 
     @Test
@@ -52,8 +58,10 @@ struct PersonRowViewTests {
         let person = try createTestPerson(dateOfBirth: nil)
         let view = PersonRowView(person: person)
 
-        _ = try view.inspect().vStack()
-        // View should render without crashing with nil DOB
+        try HostedInspection.inspect(view) { view in
+            _ = try view.inspect().vStack()
+            // View should render without crashing with nil DOB
+        }
     }
 
     @Test
@@ -61,8 +69,10 @@ struct PersonRowViewTests {
         let person = try createTestPerson(labels: [])
         let view = PersonRowView(person: person)
 
-        _ = try view.inspect().vStack()
-        // View should render without crashing even with no labels
+        try HostedInspection.inspect(view) { view in
+            _ = try view.inspect().vStack()
+            // View should render without crashing even with no labels
+        }
     }
 
     // MARK: - Style Tests
@@ -72,9 +82,11 @@ struct PersonRowViewTests {
         let person = try createTestPerson()
         let view = PersonRowView(person: person)
 
-        let vStack = try view.inspect().vStack()
-        let nameText = try vStack.text(0)
-        #expect(try nameText.attributes().font() == .headline)
+        try HostedInspection.inspect(view) { view in
+            let vStack = try view.inspect().vStack()
+            let nameText = try vStack.text(0)
+            #expect(try nameText.attributes().font() == .headline)
+        }
     }
 
     @Test
@@ -83,6 +95,8 @@ struct PersonRowViewTests {
         let view = PersonRowView(person: person)
 
         // Just verify the view structure can be inspected
-        _ = try view.inspect()
+        try HostedInspection.inspect(view) { view in
+            _ = try view.inspect()
+        }
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Home/RecordTypeRowViewTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Home/RecordTypeRowViewTests.swift
@@ -11,29 +11,35 @@ struct RecordTypeRowViewTests {
     func viewDisplaysRecordTypeName() throws {
         let view = RecordTypeRowView(recordType: .immunization, recordCount: 3)
 
-        let hStack = try view.inspect().hStack()
-        let nameText = try hStack.text(1)
-        #expect(try nameText.string() == "Immunization")
+        try HostedInspection.inspect(view) { view in
+            let hStack = try view.inspect().hStack()
+            let nameText = try hStack.text(1)
+            #expect(try nameText.string() == "Immunization")
+        }
     }
 
     @Test
     func viewDisplaysRecordCount() throws {
         let view = RecordTypeRowView(recordType: .condition, recordCount: 5)
 
-        let hStack = try view.inspect().hStack()
-        // HStack has: Image(0), Text(1), Spacer(2), Text(3) when count > 0
-        let countText = try hStack.text(3)
-        #expect(try countText.string() == "5")
+        try HostedInspection.inspect(view) { view in
+            let hStack = try view.inspect().hStack()
+            // HStack has: Image(0), Text(1), Spacer(2), Text(3) when count > 0
+            let countText = try hStack.text(3)
+            #expect(try countText.string() == "5")
+        }
     }
 
     @Test
     func viewHidesCountWhenZero() throws {
         let view = RecordTypeRowView(recordType: .medicationStatement, recordCount: 0)
 
-        let hStack = try view.inspect().hStack()
-        // Should only have image, name text, and spacer - no count
-        #expect(throws: (any Error).self) {
-            _ = try hStack.text(2)
+        try HostedInspection.inspect(view) { view in
+            let hStack = try view.inspect().hStack()
+            // Should only have image, name text, and spacer - no count
+            #expect(throws: (any Error).self) {
+                _ = try hStack.text(2)
+            }
         }
     }
 
@@ -41,10 +47,12 @@ struct RecordTypeRowViewTests {
     func viewDisplaysIcon() throws {
         let view = RecordTypeRowView(recordType: .allergyIntolerance, recordCount: 1)
 
-        let hStack = try view.inspect().hStack()
-        let image = try hStack.image(0)
-        #expect(throws: Never.self) {
-            _ = try image.actualImage()
+        try HostedInspection.inspect(view) { view in
+            let hStack = try view.inspect().hStack()
+            let image = try hStack.image(0)
+            #expect(throws: Never.self) {
+                _ = try image.actualImage()
+            }
         }
     }
 
@@ -53,14 +61,18 @@ struct RecordTypeRowViewTests {
         let view = RecordTypeRowView(recordType: .clinicalNote, recordCount: 2)
 
         // Just verify the view structure can be inspected
-        _ = try view.inspect()
+        try HostedInspection.inspect(view) { view in
+            _ = try view.inspect()
+        }
     }
 
     @Test
     func viewHandlesMultipleRecordCounts() throws {
         for count in [0, 1, 5, 10, 100] {
             let view = RecordTypeRowView(recordType: .immunization, recordCount: count)
-            _ = try view.inspect()
+            try HostedInspection.inspect(view) { view in
+                _ = try view.inspect()
+            }
         }
     }
 
@@ -68,7 +80,9 @@ struct RecordTypeRowViewTests {
     func viewWorksWithAllRecordTypes() throws {
         for recordType in RecordType.allCases {
             let view = RecordTypeRowView(recordType: recordType, recordCount: 1)
-            _ = try view.inspect()
+            try HostedInspection.inspect(view) { view in
+                _ = try view.inspect()
+            }
         }
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/PasswordStrengthIndicatorTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/PasswordStrengthIndicatorTests.swift
@@ -13,11 +13,13 @@ struct PasswordStrengthIndicatorTests {
         let view = PasswordStrengthIndicator(strength: .weak)
 
         // Verify structure and weak label
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.VStack.self)
-        _ = try inspected.find(ViewType.HStack.self)
-        let strengthText = try inspected.find(text: "Weak")
-        #expect(try strengthText.string() == "Weak")
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.VStack.self)
+            _ = try inspected.find(ViewType.HStack.self)
+            let strengthText = try inspected.find(text: "Weak")
+            #expect(try strengthText.string() == "Weak")
+        }
     }
 
     @Test
@@ -25,10 +27,12 @@ struct PasswordStrengthIndicatorTests {
         let view = PasswordStrengthIndicator(strength: .fair)
 
         // Verify structure and fair label
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.VStack.self)
-        let strengthText = try inspected.find(text: "Fair")
-        #expect(try strengthText.string() == "Fair")
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.VStack.self)
+            let strengthText = try inspected.find(text: "Fair")
+            #expect(try strengthText.string() == "Fair")
+        }
     }
 
     @Test
@@ -36,10 +40,12 @@ struct PasswordStrengthIndicatorTests {
         let view = PasswordStrengthIndicator(strength: .good)
 
         // Verify structure and good label
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.VStack.self)
-        let strengthText = try inspected.find(text: "Good")
-        #expect(try strengthText.string() == "Good")
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.VStack.self)
+            let strengthText = try inspected.find(text: "Good")
+            #expect(try strengthText.string() == "Good")
+        }
     }
 
     @Test
@@ -47,10 +53,12 @@ struct PasswordStrengthIndicatorTests {
         let view = PasswordStrengthIndicator(strength: .strong)
 
         // Verify structure and strong label
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.VStack.self)
-        let strengthText = try inspected.find(text: "Strong")
-        #expect(try strengthText.string() == "Strong")
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.VStack.self)
+            let strengthText = try inspected.find(text: "Strong")
+            #expect(try strengthText.string() == "Strong")
+        }
     }
 
     @Test
@@ -58,9 +66,11 @@ struct PasswordStrengthIndicatorTests {
         let view = PasswordStrengthIndicator(strength: .good)
 
         // Verify the strength indicator contains an HStack for the bar segments
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.HStack.self)
-        // Note: ViewInspector doesn't support inspecting Rectangle/Shape primitives
-        // The presence of HStack confirms the indicator bar structure exists
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.HStack.self)
+            // Note: ViewInspector doesn't support inspecting Rectangle/Shape primitives
+            // The presence of HStack confirms the indicator bar structure exists
+        }
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Provider/ProviderDetailViewFieldTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Provider/ProviderDetailViewFieldTests.swift
@@ -1,0 +1,213 @@
+import SwiftUI
+import Testing
+import ViewInspector
+@testable import FamilyMedicalApp
+
+/// Form field presence and pre-fill tests for ProviderDetailView.
+///
+/// Split from ProviderDetailViewTests to stay within type_body_length limits.
+@MainActor
+struct ProviderDetailViewFieldTests {
+    // MARK: - Test Data
+
+    func makeTestPerson(name: String = "Test Person") throws -> Person {
+        try PersonTestHelper.makeTestPerson(name: name)
+    }
+
+    func makeProvider(
+        name: String? = "Dr. Smith",
+        organization: String? = nil,
+        specialty: String? = "Cardiology",
+        phone: String? = "555-0100",
+        address: String? = "123 Main St",
+        notes: String? = "Great doctor"
+    ) -> Provider {
+        Provider(
+            name: name,
+            organization: organization,
+            specialty: specialty,
+            phone: phone,
+            address: address,
+            notes: notes
+        )
+    }
+
+    // MARK: - Form Field Tests
+
+    @Test
+    func formHasNameField() throws {
+        let person = try makeTestPerson()
+        let view = ProviderDetailView(person: person) { _ in true }
+
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let form = try inspected.find(ViewType.Form.self)
+            // Provider Information section has Name, Organization, Specialty
+            _ = try form.find(ViewType.TextField.self) {
+                try $0.labelView().text().string() == "Name"
+            }
+        }
+    }
+
+    @Test
+    func formHasOrganizationField() throws {
+        let person = try makeTestPerson()
+        let view = ProviderDetailView(person: person) { _ in true }
+
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let form = try inspected.find(ViewType.Form.self)
+            _ = try form.find(ViewType.TextField.self) {
+                try $0.labelView().text().string() == "Organization"
+            }
+        }
+    }
+
+    @Test
+    func formHasSpecialtyField() throws {
+        let person = try makeTestPerson()
+        let view = ProviderDetailView(person: person) { _ in true }
+
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let form = try inspected.find(ViewType.Form.self)
+            _ = try form.find(ViewType.TextField.self) {
+                try $0.labelView().text().string() == "Specialty"
+            }
+        }
+    }
+
+    @Test
+    func formHasPhoneField() throws {
+        let person = try makeTestPerson()
+        let view = ProviderDetailView(person: person) { _ in true }
+
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let form = try inspected.find(ViewType.Form.self)
+            _ = try form.find(ViewType.TextField.self) {
+                try $0.labelView().text().string() == "Phone"
+            }
+        }
+    }
+
+    @Test
+    func formHasAddressField() throws {
+        let person = try makeTestPerson()
+        let view = ProviderDetailView(person: person) { _ in true }
+
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let form = try inspected.find(ViewType.Form.self)
+            _ = try form.find(ViewType.TextField.self) {
+                try $0.labelView().text().string() == "Address"
+            }
+        }
+    }
+
+    @Test
+    func formHasNotesField() throws {
+        let person = try makeTestPerson()
+        let view = ProviderDetailView(person: person) { _ in true }
+
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let form = try inspected.find(ViewType.Form.self)
+            _ = try form.find(ViewType.TextEditor.self)
+        }
+    }
+
+    // MARK: - Pre-filled Data Tests
+
+    @Test
+    func formPreFillsNameFromExistingProvider() throws {
+        let person = try makeTestPerson()
+        let existingProvider = makeProvider(name: "Dr. Jane Doe")
+        let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
+
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let nameField = try inspected.find(ViewType.TextField.self) {
+                try $0.labelView().text().string() == "Name"
+            }
+            let inputValue = try nameField.input()
+            #expect(inputValue == "Dr. Jane Doe")
+        }
+    }
+
+    @Test
+    func formPreFillsOrganizationFromExistingProvider() throws {
+        let person = try makeTestPerson()
+        let existingProvider = makeProvider(name: "Dr. Smith", organization: "City Hospital")
+        let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
+
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let orgField = try inspected.find(ViewType.TextField.self) {
+                try $0.labelView().text().string() == "Organization"
+            }
+            let inputValue = try orgField.input()
+            #expect(inputValue == "City Hospital")
+        }
+    }
+
+    @Test
+    func formPreFillsSpecialtyFromExistingProvider() throws {
+        let person = try makeTestPerson()
+        let existingProvider = makeProvider(specialty: "Neurology")
+        let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
+
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let specialtyField = try inspected.find(ViewType.TextField.self) {
+                try $0.labelView().text().string() == "Specialty"
+            }
+            let inputValue = try specialtyField.input()
+            #expect(inputValue == "Neurology")
+        }
+    }
+
+    @Test
+    func formPreFillsPhoneFromExistingProvider() throws {
+        let person = try makeTestPerson()
+        let existingProvider = makeProvider(phone: "555-1234")
+        let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
+
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let phoneField = try inspected.find(ViewType.TextField.self) {
+                try $0.labelView().text().string() == "Phone"
+            }
+            let inputValue = try phoneField.input()
+            #expect(inputValue == "555-1234")
+        }
+    }
+
+    @Test
+    func formPreFillsAddressFromExistingProvider() throws {
+        let person = try makeTestPerson()
+        let existingProvider = makeProvider(address: "456 Oak Ave")
+        let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
+
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let addressField = try inspected.find(ViewType.TextField.self) {
+                try $0.labelView().text().string() == "Address"
+            }
+            let inputValue = try addressField.input()
+            #expect(inputValue == "456 Oak Ave")
+        }
+    }
+
+    @Test
+    func formPreFillsNotesFromExistingProvider() throws {
+        let person = try makeTestPerson()
+        let existingProvider = makeProvider(notes: "Very helpful")
+        let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
+
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.TextEditor.self)
+        }
+    }
+}

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Provider/ProviderDetailViewFieldTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Provider/ProviderDetailViewFieldTests.swift
@@ -8,35 +8,11 @@ import ViewInspector
 /// Split from ProviderDetailViewTests to stay within type_body_length limits.
 @MainActor
 struct ProviderDetailViewFieldTests {
-    // MARK: - Test Data
-
-    func makeTestPerson(name: String = "Test Person") throws -> Person {
-        try PersonTestHelper.makeTestPerson(name: name)
-    }
-
-    func makeProvider(
-        name: String? = "Dr. Smith",
-        organization: String? = nil,
-        specialty: String? = "Cardiology",
-        phone: String? = "555-0100",
-        address: String? = "123 Main St",
-        notes: String? = "Great doctor"
-    ) -> Provider {
-        Provider(
-            name: name,
-            organization: organization,
-            specialty: specialty,
-            phone: phone,
-            address: address,
-            notes: notes
-        )
-    }
-
     // MARK: - Form Field Tests
 
     @Test
     func formHasNameField() throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let view = ProviderDetailView(person: person) { _ in true }
 
         try HostedInspection.inspect(view) { view in
@@ -51,7 +27,7 @@ struct ProviderDetailViewFieldTests {
 
     @Test
     func formHasOrganizationField() throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let view = ProviderDetailView(person: person) { _ in true }
 
         try HostedInspection.inspect(view) { view in
@@ -65,7 +41,7 @@ struct ProviderDetailViewFieldTests {
 
     @Test
     func formHasSpecialtyField() throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let view = ProviderDetailView(person: person) { _ in true }
 
         try HostedInspection.inspect(view) { view in
@@ -79,7 +55,7 @@ struct ProviderDetailViewFieldTests {
 
     @Test
     func formHasPhoneField() throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let view = ProviderDetailView(person: person) { _ in true }
 
         try HostedInspection.inspect(view) { view in
@@ -93,7 +69,7 @@ struct ProviderDetailViewFieldTests {
 
     @Test
     func formHasAddressField() throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let view = ProviderDetailView(person: person) { _ in true }
 
         try HostedInspection.inspect(view) { view in
@@ -107,7 +83,7 @@ struct ProviderDetailViewFieldTests {
 
     @Test
     func formHasNotesField() throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let view = ProviderDetailView(person: person) { _ in true }
 
         try HostedInspection.inspect(view) { view in
@@ -121,8 +97,8 @@ struct ProviderDetailViewFieldTests {
 
     @Test
     func formPreFillsNameFromExistingProvider() throws {
-        let person = try makeTestPerson()
-        let existingProvider = makeProvider(name: "Dr. Jane Doe")
+        let person = try PersonTestHelper.makeTestPerson()
+        let existingProvider = ProviderTestHelper.makeProvider(name: "Dr. Jane Doe")
         let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
 
         try HostedInspection.inspect(view) { view in
@@ -137,8 +113,8 @@ struct ProviderDetailViewFieldTests {
 
     @Test
     func formPreFillsOrganizationFromExistingProvider() throws {
-        let person = try makeTestPerson()
-        let existingProvider = makeProvider(name: "Dr. Smith", organization: "City Hospital")
+        let person = try PersonTestHelper.makeTestPerson()
+        let existingProvider = ProviderTestHelper.makeProvider(name: "Dr. Smith", organization: "City Hospital")
         let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
 
         try HostedInspection.inspect(view) { view in
@@ -153,8 +129,8 @@ struct ProviderDetailViewFieldTests {
 
     @Test
     func formPreFillsSpecialtyFromExistingProvider() throws {
-        let person = try makeTestPerson()
-        let existingProvider = makeProvider(specialty: "Neurology")
+        let person = try PersonTestHelper.makeTestPerson()
+        let existingProvider = ProviderTestHelper.makeProvider(specialty: "Neurology")
         let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
 
         try HostedInspection.inspect(view) { view in
@@ -169,8 +145,8 @@ struct ProviderDetailViewFieldTests {
 
     @Test
     func formPreFillsPhoneFromExistingProvider() throws {
-        let person = try makeTestPerson()
-        let existingProvider = makeProvider(phone: "555-1234")
+        let person = try PersonTestHelper.makeTestPerson()
+        let existingProvider = ProviderTestHelper.makeProvider(phone: "555-1234")
         let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
 
         try HostedInspection.inspect(view) { view in
@@ -185,8 +161,8 @@ struct ProviderDetailViewFieldTests {
 
     @Test
     func formPreFillsAddressFromExistingProvider() throws {
-        let person = try makeTestPerson()
-        let existingProvider = makeProvider(address: "456 Oak Ave")
+        let person = try PersonTestHelper.makeTestPerson()
+        let existingProvider = ProviderTestHelper.makeProvider(address: "456 Oak Ave")
         let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
 
         try HostedInspection.inspect(view) { view in
@@ -201,8 +177,8 @@ struct ProviderDetailViewFieldTests {
 
     @Test
     func formPreFillsNotesFromExistingProvider() throws {
-        let person = try makeTestPerson()
-        let existingProvider = makeProvider(notes: "Very helpful")
+        let person = try PersonTestHelper.makeTestPerson()
+        let existingProvider = ProviderTestHelper.makeProvider(notes: "Very helpful")
         let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
 
         try HostedInspection.inspect(view) { view in

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Provider/ProviderDetailViewTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Provider/ProviderDetailViewTests.swift
@@ -8,35 +8,11 @@ import ViewInspector
 /// Field presence and pre-fill tests live in ProviderDetailViewFieldTests.
 @MainActor
 struct ProviderDetailViewTests {
-    // MARK: - Test Data
-
-    func makeTestPerson(name: String = "Test Person") throws -> Person {
-        try PersonTestHelper.makeTestPerson(name: name)
-    }
-
-    func makeProvider(
-        name: String? = "Dr. Smith",
-        organization: String? = nil,
-        specialty: String? = "Cardiology",
-        phone: String? = "555-0100",
-        address: String? = "123 Main St",
-        notes: String? = "Great doctor"
-    ) -> Provider {
-        Provider(
-            name: name,
-            organization: organization,
-            specialty: specialty,
-            phone: phone,
-            address: address,
-            notes: notes
-        )
-    }
-
     // MARK: - Create Mode Tests
 
     @Test
     func viewRendersInCreateMode() throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let view = ProviderDetailView(person: person) { _ in true }
 
         try HostedInspection.inspect(view) { view in
@@ -47,7 +23,7 @@ struct ProviderDetailViewTests {
 
     @Test
     func viewRendersFormInCreateMode() throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let view = ProviderDetailView(person: person) { _ in true }
 
         try HostedInspection.inspect(view) { view in
@@ -58,7 +34,7 @@ struct ProviderDetailViewTests {
 
     @Test
     func viewShowsUXHintInCreateMode() throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let view = ProviderDetailView(person: person) { _ in true }
 
         try HostedInspection.inspect(view) { view in
@@ -69,8 +45,8 @@ struct ProviderDetailViewTests {
 
     @Test
     func viewDoesNotShowUXHintInEditMode() throws {
-        let person = try makeTestPerson()
-        let existingProvider = makeProvider()
+        let person = try PersonTestHelper.makeTestPerson()
+        let existingProvider = ProviderTestHelper.makeProvider()
         let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
 
         try HostedInspection.inspect(view) { view in
@@ -86,8 +62,8 @@ struct ProviderDetailViewTests {
 
     @Test
     func viewRendersInEditMode() throws {
-        let person = try makeTestPerson()
-        let existingProvider = makeProvider()
+        let person = try PersonTestHelper.makeTestPerson()
+        let existingProvider = ProviderTestHelper.makeProvider()
         let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
 
         try HostedInspection.inspect(view) { view in
@@ -98,8 +74,8 @@ struct ProviderDetailViewTests {
 
     @Test
     func viewRendersFormInEditMode() throws {
-        let person = try makeTestPerson()
-        let existingProvider = makeProvider()
+        let person = try PersonTestHelper.makeTestPerson()
+        let existingProvider = ProviderTestHelper.makeProvider()
         let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
 
         try HostedInspection.inspect(view) { view in
@@ -112,7 +88,7 @@ struct ProviderDetailViewTests {
 
     @Test
     func saveButtonExists() throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let view = ProviderDetailView(person: person) { _ in true }
 
         try HostedInspection.inspect(view) { view in
@@ -123,7 +99,7 @@ struct ProviderDetailViewTests {
 
     @Test
     func cancelButtonExists() throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let view = ProviderDetailView(person: person) { _ in true }
 
         try HostedInspection.inspect(view) { view in
@@ -136,7 +112,7 @@ struct ProviderDetailViewTests {
 
     @Test
     func formHasProviderInformationSection() throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let view = ProviderDetailView(person: person) { _ in true }
 
         try HostedInspection.inspect(view) { view in
@@ -150,7 +126,7 @@ struct ProviderDetailViewTests {
 
     @Test
     func formHasContactSection() throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let view = ProviderDetailView(person: person) { _ in true }
 
         try HostedInspection.inspect(view) { view in
@@ -163,7 +139,7 @@ struct ProviderDetailViewTests {
 
     @Test
     func formHasNotesSection() throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let view = ProviderDetailView(person: person) { _ in true }
 
         try HostedInspection.inspect(view) { view in
@@ -176,8 +152,8 @@ struct ProviderDetailViewTests {
 
     @Test
     func editModeFormHasExpectedSections() throws {
-        let person = try makeTestPerson()
-        let existingProvider = makeProvider()
+        let person = try PersonTestHelper.makeTestPerson()
+        let existingProvider = ProviderTestHelper.makeProvider()
         let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
 
         try HostedInspection.inspect(view) { view in
@@ -195,7 +171,7 @@ struct ProviderDetailViewTests {
 
     @Test
     func createModeFieldsStartEmpty() throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let view = ProviderDetailView(person: person) { _ in true }
 
         try HostedInspection.inspect(view) { view in
@@ -210,7 +186,7 @@ struct ProviderDetailViewTests {
 
     @Test
     func viewRendersWithAllProviderFields() throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let existingProvider = Provider(
             name: "Dr. Full",
             organization: "Full Org",

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Provider/ProviderDetailViewTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Provider/ProviderDetailViewTests.swift
@@ -3,6 +3,9 @@ import Testing
 import ViewInspector
 @testable import FamilyMedicalApp
 
+/// Structural, mode, button, and section tests for ProviderDetailView.
+///
+/// Field presence and pre-fill tests live in ProviderDetailViewFieldTests.
 @MainActor
 struct ProviderDetailViewTests {
     // MARK: - Test Data
@@ -36,8 +39,10 @@ struct ProviderDetailViewTests {
         let person = try makeTestPerson()
         let view = ProviderDetailView(person: person) { _ in true }
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.NavigationStack.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.NavigationStack.self)
+        }
     }
 
     @Test
@@ -45,8 +50,10 @@ struct ProviderDetailViewTests {
         let person = try makeTestPerson()
         let view = ProviderDetailView(person: person) { _ in true }
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.Form.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.Form.self)
+        }
     }
 
     @Test
@@ -54,8 +61,10 @@ struct ProviderDetailViewTests {
         let person = try makeTestPerson()
         let view = ProviderDetailView(person: person) { _ in true }
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(text: "Is this a person or a practice? Fill in their name, organization, or both.")
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(text: "Is this a person or a practice? Fill in their name, organization, or both.")
+        }
     }
 
     @Test
@@ -64,11 +73,13 @@ struct ProviderDetailViewTests {
         let existingProvider = makeProvider()
         let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
 
-        let inspected = try view.inspect()
-        // In edit mode, the hint section should not be present
-        let hintText = try? inspected
-            .find(text: "Is this a person or a practice? Fill in their name, organization, or both.")
-        #expect(hintText == nil)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            // In edit mode, the hint section should not be present
+            let hintText = try? inspected
+                .find(text: "Is this a person or a practice? Fill in their name, organization, or both.")
+            #expect(hintText == nil)
+        }
     }
 
     // MARK: - Edit Mode Tests
@@ -79,8 +90,10 @@ struct ProviderDetailViewTests {
         let existingProvider = makeProvider()
         let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.NavigationStack.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.NavigationStack.self)
+        }
     }
 
     @Test
@@ -89,163 +102,10 @@ struct ProviderDetailViewTests {
         let existingProvider = makeProvider()
         let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.Form.self)
-    }
-
-    // MARK: - Form Field Tests
-
-    @Test
-    func formHasNameField() throws {
-        let person = try makeTestPerson()
-        let view = ProviderDetailView(person: person) { _ in true }
-
-        let inspected = try view.inspect()
-        let form = try inspected.find(ViewType.Form.self)
-        // Provider Information section has Name, Organization, Specialty
-        _ = try form.find(ViewType.TextField.self) {
-            try $0.labelView().text().string() == "Name"
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.Form.self)
         }
-    }
-
-    @Test
-    func formHasOrganizationField() throws {
-        let person = try makeTestPerson()
-        let view = ProviderDetailView(person: person) { _ in true }
-
-        let inspected = try view.inspect()
-        let form = try inspected.find(ViewType.Form.self)
-        _ = try form.find(ViewType.TextField.self) {
-            try $0.labelView().text().string() == "Organization"
-        }
-    }
-
-    @Test
-    func formHasSpecialtyField() throws {
-        let person = try makeTestPerson()
-        let view = ProviderDetailView(person: person) { _ in true }
-
-        let inspected = try view.inspect()
-        let form = try inspected.find(ViewType.Form.self)
-        _ = try form.find(ViewType.TextField.self) {
-            try $0.labelView().text().string() == "Specialty"
-        }
-    }
-
-    @Test
-    func formHasPhoneField() throws {
-        let person = try makeTestPerson()
-        let view = ProviderDetailView(person: person) { _ in true }
-
-        let inspected = try view.inspect()
-        let form = try inspected.find(ViewType.Form.self)
-        _ = try form.find(ViewType.TextField.self) {
-            try $0.labelView().text().string() == "Phone"
-        }
-    }
-
-    @Test
-    func formHasAddressField() throws {
-        let person = try makeTestPerson()
-        let view = ProviderDetailView(person: person) { _ in true }
-
-        let inspected = try view.inspect()
-        let form = try inspected.find(ViewType.Form.self)
-        _ = try form.find(ViewType.TextField.self) {
-            try $0.labelView().text().string() == "Address"
-        }
-    }
-
-    @Test
-    func formHasNotesField() throws {
-        let person = try makeTestPerson()
-        let view = ProviderDetailView(person: person) { _ in true }
-
-        let inspected = try view.inspect()
-        let form = try inspected.find(ViewType.Form.self)
-        _ = try form.find(ViewType.TextEditor.self)
-    }
-
-    // MARK: - Pre-filled Data Tests
-
-    @Test
-    func formPreFillsNameFromExistingProvider() throws {
-        let person = try makeTestPerson()
-        let existingProvider = makeProvider(name: "Dr. Jane Doe")
-        let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
-
-        let inspected = try view.inspect()
-        let nameField = try inspected.find(ViewType.TextField.self) {
-            try $0.labelView().text().string() == "Name"
-        }
-        let inputValue = try nameField.input()
-        #expect(inputValue == "Dr. Jane Doe")
-    }
-
-    @Test
-    func formPreFillsOrganizationFromExistingProvider() throws {
-        let person = try makeTestPerson()
-        let existingProvider = makeProvider(name: "Dr. Smith", organization: "City Hospital")
-        let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
-
-        let inspected = try view.inspect()
-        let orgField = try inspected.find(ViewType.TextField.self) {
-            try $0.labelView().text().string() == "Organization"
-        }
-        let inputValue = try orgField.input()
-        #expect(inputValue == "City Hospital")
-    }
-
-    @Test
-    func formPreFillsSpecialtyFromExistingProvider() throws {
-        let person = try makeTestPerson()
-        let existingProvider = makeProvider(specialty: "Neurology")
-        let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
-
-        let inspected = try view.inspect()
-        let specialtyField = try inspected.find(ViewType.TextField.self) {
-            try $0.labelView().text().string() == "Specialty"
-        }
-        let inputValue = try specialtyField.input()
-        #expect(inputValue == "Neurology")
-    }
-
-    @Test
-    func formPreFillsPhoneFromExistingProvider() throws {
-        let person = try makeTestPerson()
-        let existingProvider = makeProvider(phone: "555-1234")
-        let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
-
-        let inspected = try view.inspect()
-        let phoneField = try inspected.find(ViewType.TextField.self) {
-            try $0.labelView().text().string() == "Phone"
-        }
-        let inputValue = try phoneField.input()
-        #expect(inputValue == "555-1234")
-    }
-
-    @Test
-    func formPreFillsAddressFromExistingProvider() throws {
-        let person = try makeTestPerson()
-        let existingProvider = makeProvider(address: "456 Oak Ave")
-        let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
-
-        let inspected = try view.inspect()
-        let addressField = try inspected.find(ViewType.TextField.self) {
-            try $0.labelView().text().string() == "Address"
-        }
-        let inputValue = try addressField.input()
-        #expect(inputValue == "456 Oak Ave")
-    }
-
-    @Test
-    func formPreFillsNotesFromExistingProvider() throws {
-        let person = try makeTestPerson()
-        let existingProvider = makeProvider(notes: "Very helpful")
-        let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
-
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.TextEditor.self)
     }
 
     // MARK: - Button Tests
@@ -255,8 +115,10 @@ struct ProviderDetailViewTests {
         let person = try makeTestPerson()
         let view = ProviderDetailView(person: person) { _ in true }
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(button: "Save")
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(button: "Save")
+        }
     }
 
     @Test
@@ -264,8 +126,10 @@ struct ProviderDetailViewTests {
         let person = try makeTestPerson()
         let view = ProviderDetailView(person: person) { _ in true }
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(button: "Cancel")
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(button: "Cancel")
+        }
     }
 
     // MARK: - Section Tests
@@ -275,11 +139,13 @@ struct ProviderDetailViewTests {
         let person = try makeTestPerson()
         let view = ProviderDetailView(person: person) { _ in true }
 
-        let inspected = try view.inspect()
-        let form = try inspected.find(ViewType.Form.self)
-        // Create mode: section 0 is the hint, section 1 is Provider Information
-        _ = try form.section(0)
-        _ = try form.section(1)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let form = try inspected.find(ViewType.Form.self)
+            // Create mode: section 0 is the hint, section 1 is Provider Information
+            _ = try form.section(0)
+            _ = try form.section(1)
+        }
     }
 
     @Test
@@ -287,10 +153,12 @@ struct ProviderDetailViewTests {
         let person = try makeTestPerson()
         let view = ProviderDetailView(person: person) { _ in true }
 
-        let inspected = try view.inspect()
-        let form = try inspected.find(ViewType.Form.self)
-        // Create mode: section 0=hint, 1=provider info, 2=contact
-        _ = try form.section(2)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let form = try inspected.find(ViewType.Form.self)
+            // Create mode: section 0=hint, 1=provider info, 2=contact
+            _ = try form.section(2)
+        }
     }
 
     @Test
@@ -298,10 +166,12 @@ struct ProviderDetailViewTests {
         let person = try makeTestPerson()
         let view = ProviderDetailView(person: person) { _ in true }
 
-        let inspected = try view.inspect()
-        let form = try inspected.find(ViewType.Form.self)
-        // Create mode: section 0=hint, 1=provider info, 2=contact, 3=notes
-        _ = try form.section(3)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let form = try inspected.find(ViewType.Form.self)
+            // Create mode: section 0=hint, 1=provider info, 2=contact, 3=notes
+            _ = try form.section(3)
+        }
     }
 
     @Test
@@ -310,13 +180,15 @@ struct ProviderDetailViewTests {
         let existingProvider = makeProvider()
         let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
 
-        let inspected = try view.inspect()
-        let form = try inspected.find(ViewType.Form.self)
-        // Edit mode: conditional hint section is absent (Optional at index 0),
-        // so real sections start at index 1 in ViewInspector
-        _ = try form.section(1)
-        _ = try form.section(2)
-        _ = try form.section(3)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let form = try inspected.find(ViewType.Form.self)
+            // Edit mode: conditional hint section is absent (Optional at index 0),
+            // so real sections start at index 1 in ViewInspector
+            _ = try form.section(1)
+            _ = try form.section(2)
+            _ = try form.section(3)
+        }
     }
 
     // MARK: - Empty Field Tests
@@ -326,12 +198,14 @@ struct ProviderDetailViewTests {
         let person = try makeTestPerson()
         let view = ProviderDetailView(person: person) { _ in true }
 
-        let inspected = try view.inspect()
-        let nameField = try inspected.find(ViewType.TextField.self) {
-            try $0.labelView().text().string() == "Name"
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let nameField = try inspected.find(ViewType.TextField.self) {
+                try $0.labelView().text().string() == "Name"
+            }
+            let inputValue = try nameField.input()
+            #expect(inputValue.isEmpty)
         }
-        let inputValue = try nameField.input()
-        #expect(inputValue.isEmpty)
     }
 
     @Test
@@ -347,10 +221,12 @@ struct ProviderDetailViewTests {
         )
         let view = ProviderDetailView(person: person, existingProvider: existingProvider) { _ in true }
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.Form.self)
-        // Verify all text fields are present
-        let textFields = inspected.findAll(ViewType.TextField.self)
-        #expect(textFields.count == 5)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.Form.self)
+            // Verify all text fields are present
+            let textFields = inspected.findAll(ViewType.TextField.self)
+            #expect(textFields.count == 5)
+        }
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Provider/ProviderListViewTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Provider/ProviderListViewTests.swift
@@ -10,10 +10,6 @@ struct ProviderListViewTests {
 
     let testPrimaryKey = SymmetricKey(size: .bits256)
 
-    func makeTestPerson(name: String = "Test Person") throws -> Person {
-        try PersonTestHelper.makeTestPerson(name: name)
-    }
-
     func makeViewModel(
         person: Person,
         repository: MockProviderRepository = MockProviderRepository(),
@@ -32,7 +28,7 @@ struct ProviderListViewTests {
 
     @Test
     func viewRendersSuccessfully() throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let viewModel = makeViewModel(person: person)
         let view = ProviderListView(person: person, viewModel: viewModel)
 
@@ -44,7 +40,7 @@ struct ProviderListViewTests {
 
     @Test
     func viewRendersEmptyState() throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let viewModel = makeViewModel(person: person)
         // No providers, not loading -> ContentUnavailableView
         let view = ProviderListView(person: person, viewModel: viewModel)
@@ -57,7 +53,7 @@ struct ProviderListViewTests {
 
     @Test
     func viewRendersLoadingState() throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let viewModel = makeViewModel(person: person)
         viewModel.isLoading = true
         let view = ProviderListView(person: person, viewModel: viewModel)
@@ -70,7 +66,7 @@ struct ProviderListViewTests {
 
     @Test
     func viewRendersProviderListWithData() async throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let mockRepo = MockProviderRepository()
         let provider1 = Provider(name: "Dr. Smith", specialty: "Cardiology")
         let provider2 = Provider(organization: "City Hospital")
@@ -89,7 +85,7 @@ struct ProviderListViewTests {
 
     @Test
     func viewRendersProviderRows() async throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let mockRepo = MockProviderRepository()
         let provider = Provider(name: "Dr. Jones", specialty: "Pediatrics")
         mockRepo.addProvider(provider, personId: person.id)
@@ -109,7 +105,7 @@ struct ProviderListViewTests {
 
     @Test
     func viewDisplaysSearchable() throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let viewModel = makeViewModel(person: person)
         let view = ProviderListView(person: person, viewModel: viewModel)
 
@@ -123,7 +119,7 @@ struct ProviderListViewTests {
 
     @Test
     func viewHasAddButtonInToolbar() throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let viewModel = makeViewModel(person: person)
         let view = ProviderListView(person: person, viewModel: viewModel)
 
@@ -138,7 +134,7 @@ struct ProviderListViewTests {
 
     @Test
     func viewHandlesErrorState() throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let viewModel = makeViewModel(person: person)
         viewModel.errorMessage = "Unable to load providers."
 
@@ -153,7 +149,7 @@ struct ProviderListViewTests {
 
     @Test
     func viewRendersWithErrorFromRepository() async throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let mockRepo = MockProviderRepository()
         mockRepo.shouldFailFetchAll = true
 
@@ -170,7 +166,7 @@ struct ProviderListViewTests {
 
     @Test
     func providerRowDisplaysDisplayString() async throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let mockRepo = MockProviderRepository()
         let provider = Provider(name: "Dr. Adams", organization: "Health Clinic", specialty: "Dermatology")
         mockRepo.addProvider(provider, personId: person.id)
@@ -188,7 +184,7 @@ struct ProviderListViewTests {
 
     @Test
     func providerRowDisplaysSpecialty() async throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let mockRepo = MockProviderRepository()
         let provider = Provider(name: "Dr. Adams", specialty: "Dermatology")
         mockRepo.addProvider(provider, personId: person.id)
@@ -205,7 +201,7 @@ struct ProviderListViewTests {
 
     @Test
     func deleteConfirmationDialogExists() throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let viewModel = makeViewModel(person: person)
         let view = ProviderListView(person: person, viewModel: viewModel)
 
@@ -218,7 +214,7 @@ struct ProviderListViewTests {
 
     @Test
     func viewInitializesWithDefaultViewModel() throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         // Initialize without providing viewModel to test default initialization
         let view = ProviderListView(person: person)
         try HostedInspection.inspect(view) { view in
@@ -229,7 +225,7 @@ struct ProviderListViewTests {
 
     @Test
     func viewRendersMultipleProviders() async throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let mockRepo = MockProviderRepository()
 
         let providers = [
@@ -258,7 +254,7 @@ struct ProviderListViewTests {
 
     @Test
     func viewRendersProviderWithOrganizationOnly() async throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let mockRepo = MockProviderRepository()
         let provider = Provider(organization: "Sunrise Medical Center")
         mockRepo.addProvider(provider, personId: person.id)
@@ -275,7 +271,7 @@ struct ProviderListViewTests {
 
     @Test
     func viewShowsListStyleWhenProvidersExist() async throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let mockRepo = MockProviderRepository()
         mockRepo.addProvider(Provider(name: "Dr. Test"), personId: person.id)
 
@@ -292,7 +288,7 @@ struct ProviderListViewTests {
 
     @Test
     func viewRendersNavigationTitle() throws {
-        let person = try makeTestPerson(name: "Alice")
+        let person = try PersonTestHelper.makeTestPerson(name: "Alice")
         let viewModel = makeViewModel(person: person)
         let view = ProviderListView(person: person, viewModel: viewModel)
 
@@ -304,7 +300,7 @@ struct ProviderListViewTests {
 
     @Test
     func emptyStateShowsCorrectMessage() throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let viewModel = makeViewModel(person: person)
         let view = ProviderListView(person: person, viewModel: viewModel)
 
@@ -317,7 +313,7 @@ struct ProviderListViewTests {
 
     @Test
     func loadingStateOverlaysOnEmptyView() throws {
-        let person = try makeTestPerson()
+        let person = try PersonTestHelper.makeTestPerson()
         let viewModel = makeViewModel(person: person)
         viewModel.isLoading = true
         // When loading with no providers, both ContentUnavailableView

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Provider/ProviderListViewTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Provider/ProviderListViewTests.swift
@@ -36,8 +36,10 @@ struct ProviderListViewTests {
         let viewModel = makeViewModel(person: person)
         let view = ProviderListView(person: person, viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.Group.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.Group.self)
+        }
     }
 
     @Test
@@ -47,8 +49,10 @@ struct ProviderListViewTests {
         // No providers, not loading -> ContentUnavailableView
         let view = ProviderListView(person: person, viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.ContentUnavailableView.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.ContentUnavailableView.self)
+        }
     }
 
     @Test
@@ -58,8 +62,10 @@ struct ProviderListViewTests {
         viewModel.isLoading = true
         let view = ProviderListView(person: person, viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.ProgressView.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.ProgressView.self)
+        }
     }
 
     @Test
@@ -75,8 +81,10 @@ struct ProviderListViewTests {
         await viewModel.loadProviders()
 
         let view = ProviderListView(person: person, viewModel: viewModel)
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.List.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.List.self)
+        }
     }
 
     @Test
@@ -90,11 +98,13 @@ struct ProviderListViewTests {
         await viewModel.loadProviders()
 
         let view = ProviderListView(person: person, viewModel: viewModel)
-        let inspected = try view.inspect()
-        let list = try inspected.find(ViewType.List.self)
-        let forEach = try list.forEach(0)
-        // Verify at least one row exists
-        _ = try forEach.button(0)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let list = try inspected.find(ViewType.List.self)
+            let forEach = try list.forEach(0)
+            // Verify at least one row exists
+            _ = try forEach.button(0)
+        }
     }
 
     @Test
@@ -104,9 +114,11 @@ struct ProviderListViewTests {
         let view = ProviderListView(person: person, viewModel: viewModel)
 
         // Verify the view renders with searchable modifier
-        let inspected = try view.inspect()
-        // The searchable modifier is applied to the Group, verify rendering works
-        _ = try inspected.find(ViewType.Group.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            // The searchable modifier is applied to the Group, verify rendering works
+            _ = try inspected.find(ViewType.Group.self)
+        }
     }
 
     @Test
@@ -115,10 +127,12 @@ struct ProviderListViewTests {
         let viewModel = makeViewModel(person: person)
         let view = ProviderListView(person: person, viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        // Find the toolbar button with the plus image
-        _ = try inspected.find(ViewType.Image.self) { image in
-            try image.actualImage().name() == "plus"
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            // Find the toolbar button with the plus image
+            _ = try inspected.find(ViewType.Image.self) { image in
+                try image.actualImage().name() == "plus"
+            }
         }
     }
 
@@ -129,9 +143,11 @@ struct ProviderListViewTests {
         viewModel.errorMessage = "Unable to load providers."
 
         let view = ProviderListView(person: person, viewModel: viewModel)
-        let inspected = try view.inspect()
-        // View renders successfully even in error state
-        _ = try inspected.find(ViewType.Group.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            // View renders successfully even in error state
+            _ = try inspected.find(ViewType.Group.self)
+        }
         #expect(viewModel.errorMessage == "Unable to load providers.")
     }
 
@@ -145,8 +161,10 @@ struct ProviderListViewTests {
         await viewModel.loadProviders()
 
         let view = ProviderListView(person: person, viewModel: viewModel)
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.Group.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.Group.self)
+        }
         #expect(viewModel.errorMessage != nil)
     }
 
@@ -161,9 +179,11 @@ struct ProviderListViewTests {
         await viewModel.loadProviders()
 
         let view = ProviderListView(person: person, viewModel: viewModel)
-        let inspected = try view.inspect()
-        // Find text matching the provider displayString
-        _ = try inspected.find(text: "Dr. Adams at Health Clinic")
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            // Find text matching the provider displayString
+            _ = try inspected.find(text: "Dr. Adams at Health Clinic")
+        }
     }
 
     @Test
@@ -177,8 +197,10 @@ struct ProviderListViewTests {
         await viewModel.loadProviders()
 
         let view = ProviderListView(person: person, viewModel: viewModel)
-        let inspected = try view.inspect()
-        _ = try inspected.find(text: "Dermatology")
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(text: "Dermatology")
+        }
     }
 
     @Test
@@ -188,8 +210,10 @@ struct ProviderListViewTests {
         let view = ProviderListView(person: person, viewModel: viewModel)
 
         // View renders with confirmation dialog modifier
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.Group.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.Group.self)
+        }
     }
 
     @Test
@@ -197,8 +221,10 @@ struct ProviderListViewTests {
         let person = try makeTestPerson()
         // Initialize without providing viewModel to test default initialization
         let view = ProviderListView(person: person)
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.Group.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.Group.self)
+        }
     }
 
     @Test
@@ -219,13 +245,15 @@ struct ProviderListViewTests {
         await viewModel.loadProviders()
 
         let view = ProviderListView(person: person, viewModel: viewModel)
-        let inspected = try view.inspect()
-        let list = try inspected.find(ViewType.List.self)
-        let forEach = try list.forEach(0)
-        // Verify all 3 rows rendered
-        _ = try forEach.button(0)
-        _ = try forEach.button(1)
-        _ = try forEach.button(2)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let list = try inspected.find(ViewType.List.self)
+            let forEach = try list.forEach(0)
+            // Verify all 3 rows rendered
+            _ = try forEach.button(0)
+            _ = try forEach.button(1)
+            _ = try forEach.button(2)
+        }
     }
 
     @Test
@@ -239,8 +267,10 @@ struct ProviderListViewTests {
         await viewModel.loadProviders()
 
         let view = ProviderListView(person: person, viewModel: viewModel)
-        let inspected = try view.inspect()
-        _ = try inspected.find(text: "Sunrise Medical Center")
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(text: "Sunrise Medical Center")
+        }
     }
 
     @Test
@@ -253,9 +283,11 @@ struct ProviderListViewTests {
         await viewModel.loadProviders()
 
         let view = ProviderListView(person: person, viewModel: viewModel)
-        let inspected = try view.inspect()
-        // When providers exist, should show List not ContentUnavailableView
-        _ = try inspected.find(ViewType.List.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            // When providers exist, should show List not ContentUnavailableView
+            _ = try inspected.find(ViewType.List.self)
+        }
     }
 
     @Test
@@ -264,8 +296,10 @@ struct ProviderListViewTests {
         let viewModel = makeViewModel(person: person)
         let view = ProviderListView(person: person, viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.Group.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.Group.self)
+        }
     }
 
     @Test
@@ -274,9 +308,11 @@ struct ProviderListViewTests {
         let viewModel = makeViewModel(person: person)
         let view = ProviderListView(person: person, viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        let unavailable = try inspected.find(ViewType.ContentUnavailableView.self)
-        _ = unavailable
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let unavailable = try inspected.find(ViewType.ContentUnavailableView.self)
+            _ = unavailable
+        }
     }
 
     @Test
@@ -288,7 +324,9 @@ struct ProviderListViewTests {
         // (since filteredProviders is empty) and ProgressView overlay appear
         let view = ProviderListView(person: person, viewModel: viewModel)
 
-        let inspected = try view.inspect()
-        _ = try inspected.find(ViewType.ProgressView.self)
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            _ = try inspected.find(ViewType.ProgressView.self)
+        }
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Records/MedicalRecordDetailViewActionTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Records/MedicalRecordDetailViewActionTests.swift
@@ -66,11 +66,11 @@ struct MedicalRecordDetailViewActionTests {
         // which sets showingDeleteConfirmation = true. The confirmationDialog
         // content closures are lazily evaluated by SwiftUI and cannot be reached
         // through ViewInspector.
-        ViewHosting.host(view: view)
-        let inspected = try view.inspect()
-        let deleteButton = try inspected.find(button: "Delete")
-        try deleteButton.tap()
-        ViewHosting.expel()
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let deleteButton = try inspected.find(button: "Delete")
+            try deleteButton.tap()
+        }
     }
 
     @Test
@@ -85,11 +85,11 @@ struct MedicalRecordDetailViewActionTests {
             onDelete: nil
         )
 
-        ViewHosting.host(view: view)
-        let inspected = try view.inspect()
-        let deleteButton = try inspected.find(button: "Delete")
-        try deleteButton.tap()
-        ViewHosting.expel()
+        try HostedInspection.inspect(view) { view in
+            let inspected = try view.inspect()
+            let deleteButton = try inspected.find(button: "Delete")
+            try deleteButton.tap()
+        }
     }
 
     // MARK: - Edit Sheet Tests
@@ -107,17 +107,15 @@ struct MedicalRecordDetailViewActionTests {
             recordUpdated = true
         }
 
-        ViewHosting.host(view: view)
+        try HostedInspection.inspect(view) { view in
+            // Tap Edit button to present the edit sheet (exercises line 65)
+            let inspected = try view.inspect()
+            let editButton = try inspected.find(button: "Edit")
+            try editButton.tap()
 
-        // Tap Edit button to present the edit sheet (exercises line 65)
-        let inspected = try view.inspect()
-        let editButton = try inspected.find(button: "Edit")
-        try editButton.tap()
-
-        // Confirm the sheet modifier is exercised; verify record not yet updated
-        #expect(recordUpdated == false)
-
-        ViewHosting.expel()
+            // Confirm the sheet modifier is exercised; verify record not yet updated
+            #expect(recordUpdated == false)
+        }
     }
 
     // MARK: - Attachment Thumbnail Tap Tests
@@ -162,17 +160,15 @@ struct MedicalRecordDetailViewActionTests {
             detailViewModel: detailVM
         )
 
-        ViewHosting.host(view: view)
-
-        // Verify the attachment section renders with the thumbnail.
-        // DocumentThumbnailView uses .onTapGesture (not a Button) so we verify
-        // the view renders correctly; the tap action is tested at the ViewModel level.
-        let inspected = try view.inspect()
-        _ = try inspected.find(text: "Attachments")
-        let thumbnail = try inspected.find(DocumentThumbnailView.self)
-        _ = try thumbnail.find(ViewType.ZStack.self)
-
-        ViewHosting.expel()
+        try HostedInspection.inspect(view) { view in
+            // Verify the attachment section renders with the thumbnail.
+            // DocumentThumbnailView uses .onTapGesture (not a Button) so we verify
+            // the view renders correctly; the tap action is tested at the ViewModel level.
+            let inspected = try view.inspect()
+            _ = try inspected.find(text: "Attachments")
+            let thumbnail = try inspected.find(DocumentThumbnailView.self)
+            _ = try thumbnail.find(ViewType.ZStack.self)
+        }
     }
 
     // MARK: - Task and Sheet Item Tests

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Settings/SettingsViewHelperTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/Settings/SettingsViewHelperTests.swift
@@ -9,6 +9,7 @@ struct SettingsViewHelperTests {
     // MARK: - InfoRow Tests
 
     @Test("InfoRow displays label and value")
+    @MainActor
     func infoRowDisplays() {
         let row = InfoRow(label: "Test Label", value: "Test Value")
 

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/UnlockViewTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Views/UnlockViewTests.swift
@@ -202,66 +202,69 @@ struct UnlockViewTests {
     func unlockViewRendersCorrectElements(_ testCase: UnlockViewTestCase) throws {
         let viewModel = createViewModel(for: testCase)
         let view = UnlockView(viewModel: viewModel)
-        let inspectedView = try view.inspect()
+        try HostedInspection.inspect(view) { view in
+            let inspectedView = try view.inspect()
 
-        // Verify passphrase field presence
-        if testCase.expectPassphraseField {
-            // Find passphrase field by accessibility identifier (more robust than text matching)
-            let passphraseField = try? inspectedView.find(viewWithAccessibilityIdentifier: "passphraseField")
-            #expect(passphraseField != nil, "Expected passphrase field to be present")
+            // Verify passphrase field presence
+            if testCase.expectPassphraseField {
+                // Find passphrase field by accessibility identifier (more robust than text matching)
+                let passphraseField = try? inspectedView.find(viewWithAccessibilityIdentifier: "passphraseField")
+                #expect(passphraseField != nil, "Expected passphrase field to be present")
 
-            // Verify "Unlock" button is present with passphrase field
-            let unlockButton = try? inspectedView.find(viewWithAccessibilityIdentifier: "unlockButton")
-            #expect(unlockButton != nil, "Expected Unlock button to be present")
-        }
+                // Verify "Unlock" button is present with passphrase field
+                let unlockButton = try? inspectedView.find(viewWithAccessibilityIdentifier: "unlockButton")
+                #expect(unlockButton != nil, "Expected Unlock button to be present")
+            }
 
-        // Verify biometric button presence (Face ID or Touch ID icon button)
-        if testCase.expectBiometricButton {
-            // Use accessibility identifier for structural test
-            let biometricButton = try? inspectedView.find(viewWithAccessibilityIdentifier: "biometricButton")
-            #expect(biometricButton != nil, "Expected biometric button to be present")
+            // Verify biometric button presence (Face ID or Touch ID icon button)
+            if testCase.expectBiometricButton {
+                // Use accessibility identifier for structural test
+                let biometricButton = try? inspectedView.find(viewWithAccessibilityIdentifier: "biometricButton")
+                #expect(biometricButton != nil, "Expected biometric button to be present")
 
-            // Also verify correct biometry type label for behavioral correctness
-            let expectedLabel = testCase.biometryType == .faceID ? "Face ID" : "Touch ID"
-            let labelText = try? inspectedView.find(text: "Unlock with \(expectedLabel)")
-            #expect(labelText != nil, "Expected biometric button with label 'Unlock with \(expectedLabel)'")
-        }
+                // Also verify correct biometry type label for behavioral correctness
+                let expectedLabel = testCase.biometryType == .faceID ? "Face ID" : "Touch ID"
+                let labelText = try? inspectedView.find(text: "Unlock with \(expectedLabel)")
+                #expect(labelText != nil, "Expected biometric button with label 'Unlock with \(expectedLabel)'")
+            }
 
-        // Verify "Use Passphrase" button presence (in biometric mode)
-        if testCase.expectUsePassphraseButton {
-            let usePassphraseButton = try? inspectedView.find(viewWithAccessibilityIdentifier: "usePassphraseButton")
-            #expect(usePassphraseButton != nil, "Expected 'Use Passphrase' button to be present")
-        }
+            // Verify "Use Passphrase" button presence (in biometric mode)
+            if testCase.expectUsePassphraseButton {
+                let usePassphraseButton = try? inspectedView
+                    .find(viewWithAccessibilityIdentifier: "usePassphraseButton")
+                #expect(usePassphraseButton != nil, "Expected 'Use Passphrase' button to be present")
+            }
 
-        // Verify "Use Face ID/Touch ID" button presence (in passphrase mode when biometric available)
-        if testCase.expectUseBiometricButton {
-            let useBiometricButton = try? inspectedView.find(viewWithAccessibilityIdentifier: "useBiometricButton")
-            #expect(useBiometricButton != nil, "Expected 'Use Biometric' button to be present")
-        }
+            // Verify "Use Face ID/Touch ID" button presence (in passphrase mode when biometric available)
+            if testCase.expectUseBiometricButton {
+                let useBiometricButton = try? inspectedView.find(viewWithAccessibilityIdentifier: "useBiometricButton")
+                #expect(useBiometricButton != nil, "Expected 'Use Biometric' button to be present")
+            }
 
-        // Verify failed attempts text presence
-        if testCase.expectFailedAttemptsText {
-            // Use accessibility identifier for structural test
-            let failedLabel = try? inspectedView.find(viewWithAccessibilityIdentifier: "failedAttemptsLabel")
-            #expect(failedLabel != nil, "Expected failed attempts label to be present")
-        }
+            // Verify failed attempts text presence
+            if testCase.expectFailedAttemptsText {
+                // Use accessibility identifier for structural test
+                let failedLabel = try? inspectedView.find(viewWithAccessibilityIdentifier: "failedAttemptsLabel")
+                #expect(failedLabel != nil, "Expected failed attempts label to be present")
+            }
 
-        // Verify lockout message presence
-        if testCase.expectLockoutMessage {
-            // Use accessibility identifier for structural test
-            let lockoutLabel = try? inspectedView.find(viewWithAccessibilityIdentifier: "lockoutLabel")
-            #expect(lockoutLabel != nil, "Expected lockout label to be present")
-        }
+            // Verify lockout message presence
+            if testCase.expectLockoutMessage {
+                // Use accessibility identifier for structural test
+                let lockoutLabel = try? inspectedView.find(viewWithAccessibilityIdentifier: "lockoutLabel")
+                #expect(lockoutLabel != nil, "Expected lockout label to be present")
+            }
 
-        // Verify error message presence
-        if testCase.expectErrorMessage, let errorMessage = testCase.errorMessage {
-            // Use accessibility identifier for structural test
-            let errorLabel = try? inspectedView.find(viewWithAccessibilityIdentifier: "errorLabel")
-            #expect(errorLabel != nil, "Expected error label to be present")
+            // Verify error message presence
+            if testCase.expectErrorMessage, let errorMessage = testCase.errorMessage {
+                // Use accessibility identifier for structural test
+                let errorLabel = try? inspectedView.find(viewWithAccessibilityIdentifier: "errorLabel")
+                #expect(errorLabel != nil, "Expected error label to be present")
 
-            // Also verify the correct message content for behavioral correctness
-            let errorText = try? inspectedView.find(text: errorMessage)
-            #expect(errorText != nil, "Expected error message '\(errorMessage)' to be present")
+                // Also verify the correct message content for behavioral correctness
+                let errorText = try? inspectedView.find(text: errorMessage)
+                #expect(errorText != nil, "Expected error message '\(errorMessage)' to be present")
+            }
         }
     }
 
@@ -273,15 +276,17 @@ struct UnlockViewTests {
         let viewModel = AuthenticationViewModel(authService: authService)
         let view = UnlockView(viewModel: viewModel)
 
-        let inspectedView = try view.inspect()
+        try HostedInspection.inspect(view) { view in
+            let inspectedView = try view.inspect()
 
-        // Verify app title is present
-        let titleText = try? inspectedView.find(text: "Family Medical App")
-        #expect(titleText != nil, "Expected app title 'Family Medical App' to be present")
+            // Verify app title is present
+            let titleText = try? inspectedView.find(text: "Family Medical App")
+            #expect(titleText != nil, "Expected app title 'Family Medical App' to be present")
 
-        // Verify app icon (heart.text.square.fill) is present
-        let iconImage = try? inspectedView.find(ViewType.Image.self)
-        #expect(iconImage != nil, "Expected app icon image to be present")
+            // Verify app icon (heart.text.square.fill) is present
+            let iconImage = try? inspectedView.find(ViewType.Image.self)
+            #expect(iconImage != nil, "Expected app icon image to be present")
+        }
     }
 
     @Test
@@ -295,16 +300,18 @@ struct UnlockViewTests {
         viewModel.showBiometricPrompt = false
 
         let view = UnlockView(viewModel: viewModel)
-        let inspectedView = try view.inspect()
+        try HostedInspection.inspect(view) { view in
+            let inspectedView = try view.inspect()
 
-        // Verify the view renders correctly with lockout state
-        // The passphrase field should exist (passphrase mode is shown)
-        let passphraseField = try? inspectedView.find(viewWithAccessibilityIdentifier: "passphraseField")
-        #expect(passphraseField != nil, "Expected passphrase field to be present during lockout")
+            // Verify the view renders correctly with lockout state
+            // The passphrase field should exist (passphrase mode is shown)
+            let passphraseField = try? inspectedView.find(viewWithAccessibilityIdentifier: "passphraseField")
+            #expect(passphraseField != nil, "Expected passphrase field to be present during lockout")
 
-        // Verify lockout message is shown
-        let lockoutLabel = try? inspectedView.find(viewWithAccessibilityIdentifier: "lockoutLabel")
-        #expect(lockoutLabel != nil, "Expected lockout label during lockout state")
+            // Verify lockout message is shown
+            let lockoutLabel = try? inspectedView.find(viewWithAccessibilityIdentifier: "lockoutLabel")
+            #expect(lockoutLabel != nil, "Expected lockout label during lockout state")
+        }
     }
 
     @Test
@@ -318,11 +325,13 @@ struct UnlockViewTests {
         viewModel.showBiometricPrompt = true
 
         let view = UnlockView(viewModel: viewModel)
-        let inspectedView = try view.inspect()
+        try HostedInspection.inspect(view) { view in
+            let inspectedView = try view.inspect()
 
-        // Verify Face ID text is shown
-        let faceIDText = try? inspectedView.find(text: "Unlock with Face ID")
-        #expect(faceIDText != nil, "Expected 'Unlock with Face ID' text")
+            // Verify Face ID text is shown
+            let faceIDText = try? inspectedView.find(text: "Unlock with Face ID")
+            #expect(faceIDText != nil, "Expected 'Unlock with Face ID' text")
+        }
     }
 
     @Test
@@ -336,11 +345,13 @@ struct UnlockViewTests {
         viewModel.showBiometricPrompt = true
 
         let view = UnlockView(viewModel: viewModel)
-        let inspectedView = try view.inspect()
+        try HostedInspection.inspect(view) { view in
+            let inspectedView = try view.inspect()
 
-        // Verify Touch ID text is shown
-        let touchIDText = try? inspectedView.find(text: "Unlock with Touch ID")
-        #expect(touchIDText != nil, "Expected 'Unlock with Touch ID' text")
+            // Verify Touch ID text is shown
+            let touchIDText = try? inspectedView.find(text: "Unlock with Touch ID")
+            #expect(touchIDText != nil, "Expected 'Unlock with Touch ID' text")
+        }
     }
 
     @Test
@@ -354,11 +365,13 @@ struct UnlockViewTests {
         viewModel.showBiometricPrompt = false
 
         let view = UnlockView(viewModel: viewModel)
-        let inspectedView = try view.inspect()
+        try HostedInspection.inspect(view) { view in
+            let inspectedView = try view.inspect()
 
-        // Verify time format includes minutes and seconds
-        let lockoutText = try? inspectedView.find(text: "Too many failed attempts. Try again in 1m 30s")
-        #expect(lockoutText != nil, "Expected lockout message with formatted time '1m 30s'")
+            // Verify time format includes minutes and seconds
+            let lockoutText = try? inspectedView.find(text: "Too many failed attempts. Try again in 1m 30s")
+            #expect(lockoutText != nil, "Expected lockout message with formatted time '1m 30s'")
+        }
     }
 
     @Test
@@ -372,11 +385,13 @@ struct UnlockViewTests {
         viewModel.showBiometricPrompt = false
 
         let view = UnlockView(viewModel: viewModel)
-        let inspectedView = try view.inspect()
+        try HostedInspection.inspect(view) { view in
+            let inspectedView = try view.inspect()
 
-        // Verify time format shows only seconds when under a minute
-        let lockoutText = try? inspectedView.find(text: "Too many failed attempts. Try again in 45s")
-        #expect(lockoutText != nil, "Expected lockout message with formatted time '45s'")
+            // Verify time format shows only seconds when under a minute
+            let lockoutText = try? inspectedView.find(text: "Too many failed attempts. Try again in 45s")
+            #expect(lockoutText != nil, "Expected lockout message with formatted time '45s'")
+        }
     }
 
     @Test
@@ -390,10 +405,12 @@ struct UnlockViewTests {
         viewModelSingular.showBiometricPrompt = false
 
         let viewSingular = UnlockView(viewModel: viewModelSingular)
-        let inspectedSingular = try viewSingular.inspect()
+        try HostedInspection.inspect(viewSingular) { viewSingular in
+            let inspectedSingular = try viewSingular.inspect()
 
-        let singularText = try? inspectedSingular.find(text: "1 failed attempt")
-        #expect(singularText != nil, "Expected singular '1 failed attempt'")
+            let singularText = try? inspectedSingular.find(text: "1 failed attempt")
+            #expect(singularText != nil, "Expected singular '1 failed attempt'")
+        }
 
         // Test plural
         let authServicePlural = MockAuthenticationService(
@@ -404,9 +421,11 @@ struct UnlockViewTests {
         viewModelPlural.showBiometricPrompt = false
 
         let viewPlural = UnlockView(viewModel: viewModelPlural)
-        let inspectedPlural = try viewPlural.inspect()
+        try HostedInspection.inspect(viewPlural) { viewPlural in
+            let inspectedPlural = try viewPlural.inspect()
 
-        let pluralText = try? inspectedPlural.find(text: "3 failed attempts")
-        #expect(pluralText != nil, "Expected plural '3 failed attempts'")
+            let pluralText = try? inspectedPlural.find(text: "3 failed attempts")
+            #expect(pluralText != nil, "Expected plural '3 failed attempts'")
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #145.

Wrap every `try view.inspect()` call in `HostedInspection.inspect(view) { view in ... }` across the entire view test suite, silencing SwiftUI `@State` runtime warnings that fire when ViewInspector reads state storage on un-hosted views. Continues the work PR #127 started — that PR added the helper and applied it to ~88 sites; this PR extends it to every remaining view test.

- **22 test files** touched, **1 new file** added (split for SwiftLint compliance)
- **~199 `.inspect()` call sites** wrapped
- **Every view test in the suite** (30 files) now uses `HostedInspection`
- Side fixes: `@MainActor` on `SettingsViewHelperTests.infoRowDisplays()`; `MedicalRecordDetailViewActionTests` converted from inline `ViewHosting.host`/`expel` pairs to the helper
- `ProviderDetailViewTests` split into `ProviderDetailViewTests` + `ProviderDetailViewFieldTests` to respect `type_body_length` after wrapping added indentation

Includes the AGENTS.md "Day-1 Correctness" guidelines commit at the base.

## Scope notes

Issue #145 listed 18 files explicitly but its problem statement said "~23 files." The 18 enumerated files are in commit `d0a21ae`; the remaining 4 (Provider/* ×2, MedicalRecordDetailViewActionTests, ExportWarningDialogTests) are in commit `611dd7f` to fully close the issue.

`#expect(throws:)` investigation: every `#expect(throws:)` body in scope contains `try`, so no misuse exists. The negative-existence checks (`#expect(throws: InspectionError.self) { try sut.find(...) }`) are valid and preserved as-is inside the new closures.

## Test plan

- [x] `scripts/run-tests.sh` — 1641/1644 passed, 3 skipped, 0 failed
- [x] `scripts/check-coverage.sh` — 80.92% overall (up from 80.77%); all files meet thresholds
- [x] `pre-commit run --all-files` — all hooks passed (SwiftFormat, SwiftLint, rustfmt, clippy, schema validators)
- [x] MCP `XcodeRefreshCodeIssuesInFile` — zero diagnostics on every touched file
- [ ] (verify in your local Xcode UI) Issue Navigator `@State` runtime warning count drops materially on a clean run vs. main

## PR size note

This is a mostly mechanical refactor — large diff (~1.2k insertions / ~790 deletions) but high regularity. Each test follows the same `try HostedInspection.inspect(view) { view in ... }` wrap pattern from PR #127's exemplar (`Views/Records/BooleanFieldRendererTests.swift`). Reviewing one file establishes the pattern for the rest.

## Summary by Sourcery

Apply the HostedInspection helper across remaining SwiftUI view tests to host views consistently during inspection and eliminate unhosted @State access warnings.

Bug Fixes:
- Resolve SwiftUI @State runtime warnings in view tests by ensuring all inspected views are properly hosted via HostedInspection.

Enhancements:
- Split ProviderDetailView field and prefill assertions into a dedicated ProviderDetailViewFieldTests suite to keep test types within style limits.
- Clarify ProviderDetailView test responsibilities with documentation comments and mark SettingsViewHelperTests.infoRowDisplays as @MainActor for correct execution context.
- Extend AGENTS guidelines with a Day-1 Correctness section emphasizing clean, non-transitional changes.

Documentation:
- Document Day-1 Correctness expectations in AGENTS.md for future contributors.

Tests:
- Wrap remaining ViewInspector-based view tests in HostedInspection.inspect closures across the suite for consistent hosting behavior.
- Replace ad hoc ViewHosting.host/expel usage in MedicalRecordDetailViewActionTests with HostedInspection for simpler setup and teardown.
- Add ProviderDetailViewFieldTests to cover ProviderDetailView form field presence and prefilled values after splitting from the main ProviderDetailViewTests type.