### PR TITLE
docs: auth/crypto rationale + OPAQUE wire-contract docs

### DIFF
--- a/backend-rust/src/routes.rs
+++ b/backend-rust/src/routes.rs
@@ -15,8 +15,8 @@ use worker::*;
 
 /// POST `/auth/opaque/register/start` request body.
 ///
-/// - `client_identifier`: 64 hex chars = SHA-256(username), 32 bytes.
-/// - `registration_request`: base64-encoded opaque-ke `RegistrationRequest` blob.
+/// - `clientIdentifier` (Rust: `client_identifier`): 64 hex chars = SHA-256(username), 32 bytes.
+/// - `registrationRequest` (Rust: `registration_request`): base64-encoded opaque-ke `RegistrationRequest` blob.
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RegisterStartRequest {
@@ -26,7 +26,7 @@ pub struct RegisterStartRequest {
 
 /// POST `/auth/opaque/register/start` response body.
 ///
-/// - `registration_response`: base64-encoded opaque-ke `RegistrationResponse`
+/// - `registrationResponse` (Rust: `registration_response`): base64-encoded opaque-ke `RegistrationResponse`
 ///   blob the client feeds into `ClientRegistration::finish`.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -36,10 +36,10 @@ pub struct RegisterStartResponse {
 
 /// POST `/auth/opaque/register/finish` request body.
 ///
-/// - `client_identifier`: 64 hex chars (same as register/start).
-/// - `registration_record`: base64-encoded opaque-ke `RegistrationUpload`
+/// - `clientIdentifier` (Rust: `client_identifier`): 64 hex chars (same as register/start).
+/// - `registrationRecord` (Rust: `registration_record`): base64-encoded opaque-ke `RegistrationUpload`
 ///   (the password file) that the server persists as the credential.
-/// - `encrypted_bundle`: optional base64-encoded initial encrypted backup
+/// - `encryptedBundle` (Rust: `encrypted_bundle`): optional base64-encoded initial encrypted backup
 ///   bundle; when present it is stored under `bundle:<clientIdentifier>`.
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -50,6 +50,9 @@ pub struct RegisterFinishRequest {
 }
 
 /// Generic `{ "success": true }` response used by the register/finish path.
+///
+/// - `success` (Rust: `success`): always `true` on the success path; identical
+///   wire name in both languages (no camelCase rename needed).
 #[derive(Serialize)]
 pub struct SuccessResponse {
     pub success: bool,
@@ -57,8 +60,8 @@ pub struct SuccessResponse {
 
 /// POST `/auth/opaque/login/start` request body.
 ///
-/// - `client_identifier`: 64 hex chars (same as register).
-/// - `start_login_request`: base64-encoded opaque-ke `CredentialRequest` blob.
+/// - `clientIdentifier` (Rust: `client_identifier`): 64 hex chars (same as register).
+/// - `startLoginRequest` (Rust: `start_login_request`): base64-encoded opaque-ke `CredentialRequest` blob.
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LoginStartRequest {
@@ -68,8 +71,8 @@ pub struct LoginStartRequest {
 
 /// POST `/auth/opaque/login/start` response body.
 ///
-/// - `login_response`: base64-encoded opaque-ke `CredentialResponse` blob.
-/// - `state_key`: opaque server-state handle (plain string, no base64) the
+/// - `loginResponse` (Rust: `login_response`): base64-encoded opaque-ke `CredentialResponse` blob.
+/// - `stateKey` (Rust: `state_key`): opaque server-state handle (plain string, no base64) the
 ///   client must echo back on login/finish. Encodes a fake-vs-real record
 ///   discriminator per RFC 9807 §10.9; server-managed, TTL 60s.
 #[derive(Serialize)]
@@ -81,9 +84,9 @@ pub struct LoginStartResponse {
 
 /// POST `/auth/opaque/login/finish` request body.
 ///
-/// - `client_identifier`: 64 hex chars (same as register/login start).
-/// - `state_key`: exact value returned by the prior login/start response.
-/// - `finish_login_request`: base64-encoded opaque-ke `CredentialFinalization`
+/// - `clientIdentifier` (Rust: `client_identifier`): 64 hex chars (same as register/login start).
+/// - `stateKey` (Rust: `state_key`): exact value returned by the prior login/start response.
+/// - `finishLoginRequest` (Rust: `finish_login_request`): base64-encoded opaque-ke `CredentialFinalization`
 ///   blob.
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -95,9 +98,9 @@ pub struct LoginFinishRequest {
 
 /// POST `/auth/opaque/login/finish` response body.
 ///
-/// - `success`: always `true` on this success path.
-/// - `session_key`: base64-encoded opaque-ke session key derived by the server.
-/// - `encrypted_bundle`: optional base64-encoded encrypted backup bundle
+/// - `success` (Rust: `success`): always `true` on this success path.
+/// - `sessionKey` (Rust: `session_key`): base64-encoded opaque-ke session key derived by the server.
+/// - `encryptedBundle` (Rust: `encrypted_bundle`): optional base64-encoded encrypted backup bundle
 ///   associated with this account (whatever the client uploaded at
 ///   register/finish or via a subsequent update).
 #[derive(Serialize)]
@@ -108,10 +111,31 @@ pub struct LoginFinishResponse {
     pub encrypted_bundle: Option<String>,
 }
 
-/// Uniform error body returned on any 4xx/5xx from the OPAQUE endpoints.
-/// Intentionally opaque to callers — specific failure modes are intentionally
-/// not distinguished in the wire representation (defense in depth against
-/// account-enumeration oracles).
+/// Error body returned on 4xx/5xx from the OPAQUE endpoints.
+///
+/// - `error` (Rust: `error`): human-readable string. The level of detail
+///   depends on which code path produced the error:
+///
+/// **Validation and transport errors DO distinguish conditions** to aid
+/// client-side debugging. Callers see specific strings such as `"Invalid
+/// JSON: ..."`, `"Invalid clientIdentifier"`, `"Invalid registration record
+/// format"`, `"Invalid base64 in registrationRequest"`, `"Session expired"`,
+/// and `"Too many requests"` (accompanied by a `Retry-After` header).
+/// These paths leak nothing about account existence; they only describe the
+/// shape of the client's request or the state of a transient server-side
+/// session.
+///
+/// **Auth-outcome paths deliberately return uniform strings** so that the
+/// wire response does not reveal whether an account exists. Register start
+/// and register finish collapse all credential-bearing failures to
+/// `"Registration failed"`; login start and login finish collapse them to
+/// `"Authentication failed"` (or `"Invalid credential request"` for
+/// malformed OPAQUE messages, which applies equally to known and unknown
+/// users). Combined with RFC 9807 §10.9 fake-record generation in
+/// login/start, this prevents the endpoint from acting as an
+/// account-enumeration oracle per RFC 9807 §6.4.
+///
+/// See ADR-0011 for the full OPAQUE protocol flow and threat model.
 #[derive(Serialize)]
 pub struct ErrorResponse {
     pub error: String,

--- a/backend-rust/src/routes.rs
+++ b/backend-rust/src/routes.rs
@@ -5,6 +5,18 @@ use serde::{Deserialize, Serialize};
 use worker::*;
 
 // Request/Response types
+//
+// These DTOs define the HTTP wire contract between the iOS
+// `OpaqueAuthService` client and this Worker. All JSON fields use
+// `camelCase` so they line up with the Swift-side DTOs. Opaque-ke protocol
+// blobs are always base64-encoded (STANDARD, with padding); `clientIdentifier`
+// is always the 64-character lowercase-hex SHA-256 of the username
+// (32 bytes → 64 hex chars). See ADR-0011 for the full OPAQUE protocol flow.
+
+/// POST `/auth/opaque/register/start` request body.
+///
+/// - `client_identifier`: 64 hex chars = SHA-256(username), 32 bytes.
+/// - `registration_request`: base64-encoded opaque-ke `RegistrationRequest` blob.
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RegisterStartRequest {
@@ -12,12 +24,23 @@ pub struct RegisterStartRequest {
     pub registration_request: String, // base64
 }
 
+/// POST `/auth/opaque/register/start` response body.
+///
+/// - `registration_response`: base64-encoded opaque-ke `RegistrationResponse`
+///   blob the client feeds into `ClientRegistration::finish`.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RegisterStartResponse {
     pub registration_response: String, // base64
 }
 
+/// POST `/auth/opaque/register/finish` request body.
+///
+/// - `client_identifier`: 64 hex chars (same as register/start).
+/// - `registration_record`: base64-encoded opaque-ke `RegistrationUpload`
+///   (the password file) that the server persists as the credential.
+/// - `encrypted_bundle`: optional base64-encoded initial encrypted backup
+///   bundle; when present it is stored under `bundle:<clientIdentifier>`.
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RegisterFinishRequest {
@@ -26,11 +49,16 @@ pub struct RegisterFinishRequest {
     pub encrypted_bundle: Option<String>,
 }
 
+/// Generic `{ "success": true }` response used by the register/finish path.
 #[derive(Serialize)]
 pub struct SuccessResponse {
     pub success: bool,
 }
 
+/// POST `/auth/opaque/login/start` request body.
+///
+/// - `client_identifier`: 64 hex chars (same as register).
+/// - `start_login_request`: base64-encoded opaque-ke `CredentialRequest` blob.
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LoginStartRequest {
@@ -38,6 +66,12 @@ pub struct LoginStartRequest {
     pub start_login_request: String, // base64
 }
 
+/// POST `/auth/opaque/login/start` response body.
+///
+/// - `login_response`: base64-encoded opaque-ke `CredentialResponse` blob.
+/// - `state_key`: opaque server-state handle (plain string, no base64) the
+///   client must echo back on login/finish. Encodes a fake-vs-real record
+///   discriminator per RFC 9807 §10.9; server-managed, TTL 60s.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LoginStartResponse {
@@ -45,6 +79,12 @@ pub struct LoginStartResponse {
     pub state_key: String,
 }
 
+/// POST `/auth/opaque/login/finish` request body.
+///
+/// - `client_identifier`: 64 hex chars (same as register/login start).
+/// - `state_key`: exact value returned by the prior login/start response.
+/// - `finish_login_request`: base64-encoded opaque-ke `CredentialFinalization`
+///   blob.
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LoginFinishRequest {
@@ -53,6 +93,13 @@ pub struct LoginFinishRequest {
     pub finish_login_request: String, // base64
 }
 
+/// POST `/auth/opaque/login/finish` response body.
+///
+/// - `success`: always `true` on this success path.
+/// - `session_key`: base64-encoded opaque-ke session key derived by the server.
+/// - `encrypted_bundle`: optional base64-encoded encrypted backup bundle
+///   associated with this account (whatever the client uploaded at
+///   register/finish or via a subsequent update).
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LoginFinishResponse {
@@ -61,6 +108,10 @@ pub struct LoginFinishResponse {
     pub encrypted_bundle: Option<String>,
 }
 
+/// Uniform error body returned on any 4xx/5xx from the OPAQUE endpoints.
+/// Intentionally opaque to callers — specific failure modes are intentionally
+/// not distinguished in the wire representation (defense in depth against
+/// account-enumeration oracles).
 #[derive(Serialize)]
 pub struct ErrorResponse {
     pub error: String,

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Auth/AuthenticationService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Auth/AuthenticationService.swift
@@ -86,7 +86,20 @@ final class AuthenticationService: AuthenticationServiceProtocol {
     private static let verificationPlaintext = "family-medical-app-verification"
     private static let setupCompleteKey = "com.family-medical-app.account-setup-complete"
 
-    /// Rate limiting thresholds
+    /// Client-side lockout ladder applied after consecutive wrong-passphrase attempts on this install.
+    ///
+    /// This is a **local** throttle — it runs entirely on-device against
+    /// `failedAttemptsKey` / `lockoutEndTimeKey` in `UserDefaults`. It is
+    /// **not** the server-side rate limiter: the OPAQUE Worker enforces its
+    /// own per-endpoint, per-client-identifier limits in Cloudflare KV (see
+    /// `backend-rust/src/rate_limit.rs`). The two layers are independent and
+    /// intentionally so — the local ladder defends against a stranger with
+    /// the physical device, the server ladder defends against a remote
+    /// attacker burning credentials against the API.
+    ///
+    /// Ladder shape: escalating lockout windows after 3 / 4 / 5 / 6+
+    /// consecutive failures. See ADR-0011 for OPAQUE protocol context and
+    /// the server-side limits it pairs with.
     private static let rateLimitThresholds: [(attempts: Int, lockoutSeconds: Int)] = [
         (3, 30), // 3 fails = 30 seconds
         (4, 60), // 4 fails = 1 minute

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Auth/LockStateService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Auth/LockStateService.swift
@@ -34,6 +34,22 @@ final class LockStateService: LockStateServiceProtocol {
     private static let backgroundTimeKey = "com.family-medical-app.background-time"
     private static let lockTimeoutKey = "com.family-medical-app.lock-timeout"
     private static let demoModeKey = "com.family-medical-app.demo-mode"
+
+    /// Default auto-lock timeout: 300 seconds (5 minutes) of background time.
+    ///
+    /// Threat model: an unattended device left in a pocket, bag, or on a desk
+    /// is the dominant compromise scenario for a mobile medical-records app.
+    /// A short auto-lock window trades a small UX cost (re-auth after a coffee
+    /// break) for a substantially reduced surface area to a stranger who picks
+    /// up the device while it's unlocked.
+    ///
+    /// Override path: `lockTimeoutSeconds` on `LockStateServiceProtocol` is
+    /// persisted to `UserDefaults` and may be set programmatically. No settings
+    /// UI binds to this value today.
+    ///
+    /// No Phase-0 ADR currently captures session-lifetime rationale; this
+    /// default should be lifted into an ADR addendum (or a new ADR) when the
+    /// session-management story is formalised.
     private static let defaultTimeout = 300 // 5 minutes
 
     // MARK: - Properties

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Auth/OpaqueAuthService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Auth/OpaqueAuthService.swift
@@ -22,7 +22,15 @@ final class OpaqueAuthService: OpaqueAuthServiceProtocol, @unchecked Sendable {
     let session: URLSession
     let logger: CategoryLoggerProtocol
 
-    /// Default API base URL
+    /// Production OPAQUE API endpoint.
+    ///
+    /// This is the only base URL used by release builds. Tests and staging
+    /// harnesses override it via `init(baseURL:)` (dependency injection).
+    ///
+    /// There is no xcconfig- or environment-based override mechanism today;
+    /// one should be introduced before any staging deployment exists so that
+    /// release-configured binaries can be pointed at a non-production endpoint
+    /// without a code change. For now the override path is DI-only.
     private static let defaultBaseURL =
         URL(string: "https://api.recordwell.app/auth/opaque")! // swiftlint:disable:this force_unwrapping
 

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Crypto/KeyDerivationService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Crypto/KeyDerivationService.swift
@@ -2,19 +2,35 @@ import CryptoKit
 import Foundation
 import Sodium
 
-/// Protocol for password-based key derivation using Argon2id
+/// Key derivation primitives used by the encrypted-backup import/export path.
+///
+/// Account authentication derives its key material via OPAQUE (see
+/// `OpaqueAuthService` / `derivePrimaryKey(fromExportKey:)`); that path does
+/// **not** use this Argon2id primitive. The only remaining production caller
+/// of `derivePrimaryKey(from:salt:)` is `BackupFileService`, which derives a
+/// wrapping key from the user's backup passphrase to encrypt/decrypt the
+/// backup envelope. See ADR-0002 for the wider key hierarchy.
 protocol KeyDerivationServiceProtocol: Sendable {
-    /// Derive a primary key from password using Argon2id
+    /// Derive a backup-envelope wrapping key from a passphrase using Argon2id.
+    ///
+    /// Used by `BackupFileService` on backup export (with a freshly-generated
+    /// salt stored in the backup envelope) and on backup import (with the salt
+    /// read back from the envelope the user is restoring).
+    ///
+    /// `passwordBytes` is taken by value so the caller retains ownership and
+    /// can securely zero the buffer once the derivation returns (per RFC 9807
+    /// handling of password material); this service does not zero on the
+    /// caller's behalf.
+    ///
     /// - Parameters:
-    ///   - password: User's password
-    ///   - salt: 16-byte salt (generate new for new users, retrieve for existing)
-    /// - Returns: 256-bit SymmetricKey
-    /// - Throws: CryptoError on derivation failure
-    /// Derives primary key from password bytes - enables secure zeroing per RFC 9807
-    /// - Parameters:
-    ///   - passwordBytes: Password as bytes (caller responsible for zeroing after)
-    ///   - salt: Cryptographic salt
-    /// - Returns: Derived symmetric key
+    ///   - passwordBytes: Backup passphrase as bytes. Caller is responsible
+    ///     for zeroing the buffer after the call (use `secureZero`).
+    ///   - salt: 16-byte Argon2id salt. On export: generated via
+    ///     `generateSalt()` and stored alongside the ciphertext in the backup
+    ///     envelope. On import: read back from the envelope being restored.
+    /// - Returns: 256-bit `SymmetricKey` suitable as the backup-envelope
+    ///   wrapping key.
+    /// - Throws: `CryptoError` on invalid salt length or Argon2id failure.
     func derivePrimaryKey(from passwordBytes: [UInt8], salt: Data) throws -> SymmetricKey
 
     /// Derive a primary key from OPAQUE export key using HKDF

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentBlobService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentBlobService.swift
@@ -79,7 +79,25 @@ protocol DocumentBlobServiceProtocol: Sendable {
 actor DocumentBlobService: DocumentBlobServiceProtocol {
     // MARK: - Constants
 
+    /// Maximum accepted plaintext size for a single document blob: 10 MB.
+    ///
+    /// Enforced at `store(plaintext:personId:primaryKey:)`; exceeding this
+    /// surfaces to callers (and ultimately the UI) as
+    /// `ModelError.documentTooLarge(maxSizeMB:)`.
+    ///
+    /// Rationale: keeps Core Data blob encryption within the device's
+    /// per-record memory budget and keeps the eventual sync-payload size
+    /// tractable. No ADR pins this value; it is a pragmatic cap that should
+    /// be revisited when sync lands and real-world payload distributions are
+    /// known.
     static let maxFileSizeBytes = 10 * 1_024 * 1_024
+
+    /// Target edge length of generated thumbnails: 200 **pt**.
+    ///
+    /// Unit is SwiftUI points, not pixels — the renderer multiplies by the
+    /// display scale (@2x / @3x), so on current iPhones the actual bitmap is
+    /// 400 px or 600 px. Sized for list-row thumbnails where a low decode
+    /// cost matters more than full-fidelity rendering.
     static let thumbnailDimension = 200
 
     // MARK: - Types

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentBlobService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentBlobService.swift
@@ -85,19 +85,19 @@ actor DocumentBlobService: DocumentBlobServiceProtocol {
     /// surfaces to callers (and ultimately the UI) as
     /// `ModelError.documentTooLarge(maxSizeMB:)`.
     ///
-    /// Rationale: keeps Core Data blob encryption within the device's
-    /// per-record memory budget and keeps the eventual sync-payload size
-    /// tractable. No ADR pins this value; it is a pragmatic cap that should
-    /// be revisited when sync lands and real-world payload distributions are
-    /// known.
+    /// Rationale: bounds the in-memory cost of encrypting blobs and generating
+    /// thumbnails, and keeps the on-disk footprint and eventual sync-payload size
+    /// tractable. No ADR pins this value; it is a pragmatic cap that should be
+    /// revisited when sync lands and real-world payload distributions are known.
     static let maxFileSizeBytes = 10 * 1_024 * 1_024
 
-    /// Target edge length of generated thumbnails: 200 **pt**.
+    /// Target maximum edge length of generated thumbnails: 200 px.
     ///
-    /// Unit is SwiftUI points, not pixels — the renderer multiplies by the
-    /// display scale (@2x / @3x), so on current iPhones the actual bitmap is
-    /// 400 px or 600 px. Sized for list-row thumbnails where a low decode
-    /// cost matters more than full-fidelity rendering.
+    /// This value is passed to image resizing as a pixel dimension. The thumbnail
+    /// renderer uses a fixed scale of 1.0 (see ImageProcessingService.resizeIfNeeded),
+    /// so the stored bitmap's maximum edge length matches this value rather than
+    /// being multiplied by the device display scale. Sized for list-row thumbnails
+    /// where low decode cost matters more than full-fidelity rendering.
     static let thumbnailDimension = 200
 
     // MARK: - Types

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Provider/ProviderRepository.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Provider/ProviderRepository.swift
@@ -217,11 +217,31 @@ final class ProviderRepository: ProviderRepositoryProtocol, @unchecked Sendable 
 
     // MARK: - Private Helpers
 
-    /// Ensure FMK exists for a person (must already exist — providers are always under an existing person)
+    /// Retrieve the Family Member Key for the Person that owns this Provider.
+    ///
+    /// Invariant: Providers always belong to an existing Person, so the FMK
+    /// must pre-exist at the time this is called. Any failure here therefore
+    /// indicates either an upstream bug (e.g. a Person-deletion race that
+    /// left Provider rows referencing a vanished owner) or keychain
+    /// corruption — **not** a legitimate "this key hasn't been generated
+    /// yet" condition. Generating a new FMK here would silently re-key the
+    /// Person's data and break decryption of every other record under that
+    /// Person.
+    ///
+    /// Contrast with `PersonRepository.ensureFMK(for:primaryKey:)`, which is
+    /// the correct home for the "generate on first use" branch — it runs at
+    /// Person-creation time.
+    ///
+    /// All underlying errors are flattened into
+    /// `RepositoryError.keyNotAvailable` for the public surface (callers
+    /// cannot meaningfully act on keychain-internal failure types). The
+    /// original error is logged before wrapping so the underlying failure
+    /// mode is preserved in diagnostics.
     private func ensureFMK(for personID: String, primaryKey: SymmetricKey) throws -> SymmetricKey {
         do {
             return try fmkService.retrieveFMK(familyMemberID: personID, primaryKey: primaryKey)
         } catch {
+            logger.logError(error, context: "ProviderRepository.ensureFMK")
             throw RepositoryError.keyNotAvailable("Failed to retrieve FMK: \(error.localizedDescription)")
         }
     }

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Provider/ProviderRepository.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Provider/ProviderRepository.swift
@@ -241,7 +241,10 @@ final class ProviderRepository: ProviderRepositoryProtocol, @unchecked Sendable 
         do {
             return try fmkService.retrieveFMK(familyMemberID: personID, primaryKey: primaryKey)
         } catch {
-            logger.logError(error, context: "ProviderRepository.ensureFMK")
+            logger.logError(
+                error,
+                context: "ProviderRepository.ensureFMK personID=\(personID)"
+            )
             throw RepositoryError.keyNotAvailable("Failed to retrieve FMK: \(error.localizedDescription)")
         }
     }


### PR DESCRIPTION
## Summary

Second PR of the day-1-review cleanup plan. Pure documentation: adds `///` comments for defaults, constants, and wire DTOs that were previously undocumented but load-bearing.

**Why this matters:** These are the kind of values that look arbitrary to a reader ("why 300 seconds? why 10 MB?") and make future maintainers either cargo-cult the number, break it, or wedge guardrails around it. Capturing the *why* in the declaration is much cheaper than re-deriving it later.

## Findings addressed (8)

From `docs/day-1-review/2026-04-18-ready-to-fix.md`:

- **Finding 4** — `OpaqueAuthService.defaultBaseURL`: production endpoint, DI override, xcconfig TBD
- **Finding 5** — `LockStateService.defaultTimeout`: 5 minutes with unattended-device threat model
- **Finding 6** — `AuthenticationService.rateLimitThresholds`: client-local lockout ladder, distinct from server rate limiter
- **Findings 8 + 10** — `KeyDerivationServiceProtocol`: rewritten docs for backup-password KDF semantics (post-legacy-auth-removal)
- **Finding 13** — 9 OPAQUE wire DTOs in `backend-rust/src/routes.rs`: cross-language contract with iOS `OpaqueAuthService`
- **Finding 19** — `DocumentBlobService` `maxFileSizeBytes` and `thumbnailDimension`: memory/sync-budget and point-vs-pixel rationale
- **Finding 24** — `ProviderRepository.ensureFMK`: documents the "FMK must pre-exist" invariant + logs underlying error before wrapping

## What actually changed behaviorally

Only one: `ProviderRepository.ensureFMK` now calls `logger.logError(...)` before throwing `RepositoryError.keyNotAvailable`, so the original failure type is preserved in diagnostics. Everything else is comment-only.

## Test plan

- [x] `mcp__xcode__BuildProject` — 0 errors
- [x] `pre-commit run --all-files` — all hooks green
- [x] `scripts/run-tests.sh` — 1,616/1,619 passing, 0 failures, 3 skipped
- [x] `scripts/check-coverage.sh` — overall 80.73% ≥ 80%; all per-file thresholds met
- [ ] CI green on PR

## Related

- Follow-up to PR #167 (merged) and PR #168 (merged)
- PR 2/4 in the day-1-review cleanup plan. Remaining after this: `chore/delete-placeholder-backend` (findings 11, 12, 14), `refactor/id-naming` (findings 21, 22, 23). See `docs/day-1-review/tracker.md`.