### PR TITLE
refactor: repo-wide ID naming consistency sweep

### DIFF
--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Extensions/OptionalString+Trimming.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Extensions/OptionalString+Trimming.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension String? {
+    /// Return the receiver trimmed of leading/trailing whitespace and newlines,
+    /// or `nil` if the trimmed result is empty (or the receiver was already `nil`).
+    ///
+    /// Backup decoders use this to coerce strings that round-tripped through JSON
+    /// — where `nil`, `""`, and `"   "` all mean "no value" — back into the
+    /// canonical absent-value representation (`nil`) before feeding them into
+    /// model initializers that treat empty strings differently from absent ones.
+    func trimmedNonEmpty() -> String? {
+        guard let trimmed = self?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+}

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Models/Backup/PersonBackup.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Models/Backup/PersonBackup.swift
@@ -55,19 +55,11 @@ struct PersonBackup: Codable, Equatable {
             name: name,
             dateOfBirth: dateOfBirth,
             labels: labels,
-            notes: trimmedNonEmpty(notes),
-            gender: trimmedNonEmpty(gender),
-            bloodType: trimmedNonEmpty(bloodType),
+            notes: notes.trimmedNonEmpty(),
+            gender: gender.trimmedNonEmpty(),
+            bloodType: bloodType.trimmedNonEmpty(),
             createdAt: createdAt,
             updatedAt: updatedAt
         )
-    }
-
-    private func trimmedNonEmpty(_ value: String?) -> String? {
-        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !trimmed.isEmpty else {
-            return nil
-        }
-        return trimmed
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Models/Backup/ProviderBackup.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Models/Backup/ProviderBackup.swift
@@ -62,8 +62,8 @@ struct ProviderBackup: Codable, Equatable {
 
     /// Convert back to Provider model
     func toProvider() throws -> Provider {
-        let trimmedName = trimmedNonEmpty(name)
-        let trimmedOrganization = trimmedNonEmpty(organization)
+        let trimmedName = name.trimmedNonEmpty()
+        let trimmedOrganization = organization.trimmedNonEmpty()
 
         guard trimmedName != nil || trimmedOrganization != nil else {
             throw BackupError.corruptedFile
@@ -72,22 +72,14 @@ struct ProviderBackup: Codable, Equatable {
             id: id,
             name: trimmedName,
             organization: trimmedOrganization,
-            specialty: trimmedNonEmpty(specialty),
-            phone: trimmedNonEmpty(phone),
-            address: trimmedNonEmpty(address),
-            notes: trimmedNonEmpty(notes),
+            specialty: specialty.trimmedNonEmpty(),
+            phone: phone.trimmedNonEmpty(),
+            address: address.trimmedNonEmpty(),
+            notes: notes.trimmedNonEmpty(),
             createdAt: createdAt,
             updatedAt: updatedAt,
             version: version,
             previousVersionId: previousVersionId
         )
-    }
-
-    private func trimmedNonEmpty(_ value: String?) -> String? {
-        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !trimmed.isEmpty else {
-            return nil
-        }
-        return trimmed
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Backup/ExportService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Backup/ExportService.swift
@@ -100,7 +100,7 @@ final class ExportService: ExportServiceProtocol, @unchecked Sendable {
 
     private func retrieveFMK(for person: Person, primaryKey: SymmetricKey) throws -> SymmetricKey {
         do {
-            return try fmkService.retrieveFMK(familyMemberID: person.id.uuidString, primaryKey: primaryKey)
+            return try fmkService.retrieveFMK(personId: person.id.uuidString, primaryKey: primaryKey)
         } catch {
             logger.logError(error, context: "ExportService.retrieveFMK")
             throw BackupError.exportFailed("Failed to retrieve encryption key for person")

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Backup/ImportService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Backup/ImportService.swift
@@ -74,7 +74,7 @@ final class ImportService: ImportServiceProtocol, @unchecked Sendable {
 
         let fmk = fmkService.generateFMK()
         do {
-            try fmkService.storeFMK(fmk, familyMemberID: person.id.uuidString, primaryKey: primaryKey)
+            try fmkService.storeFMK(fmk, personId: person.id.uuidString, primaryKey: primaryKey)
         } catch {
             logger.logError(error, context: "ImportService.importPerson")
             throw BackupError.importFailed("Failed to create encryption key for person")

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Crypto/FamilyMemberKeyService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Crypto/FamilyMemberKeyService.swift
@@ -26,18 +26,18 @@ protocol FamilyMemberKeyServiceProtocol: Sendable {
     /// Store an FMK in Keychain (wrapped with primary key internally)
     /// - Parameters:
     ///   - fmk: Family Member Key to store
-    ///   - familyMemberID: Unique identifier for the family member
+    ///   - personId: Unique identifier for the person this FMK belongs to
     ///   - primaryKey: User's primary key for wrapping
     /// - Throws: CryptoError or KeychainError on failure
-    func storeFMK(_ fmk: SymmetricKey, familyMemberID: String, primaryKey: SymmetricKey) throws
+    func storeFMK(_ fmk: SymmetricKey, personId: String, primaryKey: SymmetricKey) throws
 
     /// Retrieve an FMK from Keychain
     /// - Parameters:
-    ///   - familyMemberID: Unique identifier for the family member
+    ///   - personId: Unique identifier for the person this FMK belongs to
     ///   - primaryKey: User's primary key for unwrapping
     /// - Returns: Unwrapped FMK
     /// - Throws: KeychainError or CryptoError on failure
-    func retrieveFMK(familyMemberID: String, primaryKey: SymmetricKey) throws -> SymmetricKey
+    func retrieveFMK(personId: String, primaryKey: SymmetricKey) throws -> SymmetricKey
 }
 
 /// Family Member Key management service
@@ -74,14 +74,14 @@ final class FamilyMemberKeyService: FamilyMemberKeyServiceProtocol {
     /// Store an FMK in Keychain (wrapped with primary key internally)
     /// - Parameters:
     ///   - fmk: Family Member Key to store
-    ///   - familyMemberID: Unique identifier for the family member
+    ///   - personId: Unique identifier for the person this FMK belongs to
     ///   - primaryKey: User's primary key for wrapping
     /// - Throws: CryptoError or KeychainError on failure
-    func storeFMK(_ fmk: SymmetricKey, familyMemberID: String, primaryKey: SymmetricKey) throws {
+    func storeFMK(_ fmk: SymmetricKey, personId: String, primaryKey: SymmetricKey) throws {
         let wrappedFMK = try wrapFMK(fmk, with: primaryKey)
         let wrappedKey = SymmetricKey(data: wrappedFMK)
 
-        let identifier = "fmk.\(familyMemberID)"
+        let identifier = "fmk.\(personId)"
         try keychainService.storeKey(
             wrappedKey,
             identifier: identifier,
@@ -91,12 +91,12 @@ final class FamilyMemberKeyService: FamilyMemberKeyServiceProtocol {
 
     /// Retrieve an FMK from Keychain
     /// - Parameters:
-    ///   - familyMemberID: Unique identifier for the family member
+    ///   - personId: Unique identifier for the person this FMK belongs to
     ///   - primaryKey: User's primary key for unwrapping
     /// - Returns: Unwrapped FMK
     /// - Throws: KeychainError or CryptoError on failure
-    func retrieveFMK(familyMemberID: String, primaryKey: SymmetricKey) throws -> SymmetricKey {
-        let identifier = "fmk.\(familyMemberID)"
+    func retrieveFMK(personId: String, primaryKey: SymmetricKey) throws -> SymmetricKey {
+        let identifier = "fmk.\(personId)"
         let wrappedKey = try keychainService.retrieveKey(identifier: identifier)
 
         let wrappedFMK = wrappedKey.withUnsafeBytes { Data($0) }

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Crypto/KeychainService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Crypto/KeychainService.swift
@@ -25,7 +25,7 @@ protocol KeychainServiceProtocol: Sendable {
     /// Store a symmetric key in Keychain
     /// - Parameters:
     ///   - key: SymmetricKey to store
-    ///   - identifier: Unique identifier (e.g., "primary-key.userID")
+    ///   - identifier: Unique identifier (e.g., "primary-key.userId")
     ///   - accessControl: Keychain access level
     /// - Throws: KeychainError on failure
     func storeKey(_ key: SymmetricKey, identifier: String, accessControl: KeychainAccessControl) throws

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentBlobService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentBlobService.swift
@@ -165,7 +165,7 @@ actor DocumentBlobService: DocumentBlobServiceProtocol {
         // processed size) are logged later via a regular debug line.
         logger.entry("store", "personId=\(personId), plaintextSize=\(plaintext.count)")
         do {
-            let fmk = try fmkService.retrieveFMK(familyMemberID: personId.uuidString, primaryKey: primaryKey)
+            let fmk = try fmkService.retrieveFMK(personId: personId.uuidString, primaryKey: primaryKey)
             let processed = try process(plaintext: plaintext)
             logger.debug("store detectedMime=\(processed.detectedMimeType), processedSize=\(processed.data.count)")
             let hmac = Data(HMAC<SHA256>.authenticationCode(for: processed.data, using: fmk))
@@ -208,7 +208,7 @@ actor DocumentBlobService: DocumentBlobServiceProtocol {
         let start = ContinuousClock.now
         logger.entry("retrieve", "personId=\(personId)")
         do {
-            let fmk = try fmkService.retrieveFMK(familyMemberID: personId.uuidString, primaryKey: primaryKey)
+            let fmk = try fmkService.retrieveFMK(personId: personId.uuidString, primaryKey: primaryKey)
             let encrypted = try fileStorage.retrieve(contentHMAC: contentHMAC, personId: personId)
             let plaintext: Data
             do {

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Logging/LoggingService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Logging/LoggingService.swift
@@ -56,8 +56,8 @@ protocol CategoryLoggerProtocol: Sendable {
     func logOperation(_ operation: String, state: String)
 
     /// Log a user ID (UUID) - pseudonymous, safe to log publicly
-    /// - Parameter userID: The user's UUID
-    func logUserID(_ userID: String)
+    /// - Parameter userId: The user's UUID
+    func logUserId(_ userId: String)
 
     /// Log a record count - safe metadata
     /// - Parameter count: Number of records
@@ -227,8 +227,8 @@ final class CategoryLogger: CategoryLoggerProtocol, @unchecked Sendable {
             .info("[\(category, privacy: .public)] \(operation, privacy: .public): \(state, privacy: .public)")
     }
 
-    func logUserID(_ userID: String) {
-        osLogger.debug("userID: \(userID, privacy: .public)")
+    func logUserId(_ userId: String) {
+        osLogger.debug("userId: \(userId, privacy: .public)")
     }
 
     func logRecordCount(_ count: Int) {

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Logging/TracingCategoryLogger.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Logging/TracingCategoryLogger.swift
@@ -106,8 +106,8 @@ final class TracingCategoryLogger: CategoryLoggerProtocol, @unchecked Sendable {
         inner.logOperation(operation, state: state)
     }
 
-    func logUserID(_ userID: String) {
-        inner.logUserID(userID)
+    func logUserId(_ userId: String) {
+        inner.logUserId(userId)
     }
 
     func logRecordCount(_ count: Int) {

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Provider/ProviderRepository.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Provider/ProviderRepository.swift
@@ -237,13 +237,13 @@ final class ProviderRepository: ProviderRepositoryProtocol, @unchecked Sendable 
     /// cannot meaningfully act on keychain-internal failure types). The
     /// original error is logged before wrapping so the underlying failure
     /// mode is preserved in diagnostics.
-    private func ensureFMK(for personID: String, primaryKey: SymmetricKey) throws -> SymmetricKey {
+    private func ensureFMK(for personId: String, primaryKey: SymmetricKey) throws -> SymmetricKey {
         do {
-            return try fmkService.retrieveFMK(familyMemberID: personID, primaryKey: primaryKey)
+            return try fmkService.retrieveFMK(personId: personId, primaryKey: primaryKey)
         } catch {
             logger.logError(
                 error,
-                context: "ProviderRepository.ensureFMK personID=\(personID)"
+                context: "ProviderRepository.ensureFMK personId=\(personId)"
             )
             throw RepositoryError.keyNotAvailable("Failed to retrieve FMK: \(error.localizedDescription)")
         }

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Records/DocumentReferenceQueryService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Records/DocumentReferenceQueryService.swift
@@ -114,7 +114,7 @@ final class DocumentReferenceQueryService: DocumentReferenceQueryServiceProtocol
         let start = ContinuousClock.now
         logger.entry("fetchAllDocumentReferences")
         do {
-            let fmk = try fmkService.retrieveFMK(familyMemberID: personId.uuidString, primaryKey: primaryKey)
+            let fmk = try fmkService.retrieveFMK(personId: personId.uuidString, primaryKey: primaryKey)
             let records = try await recordRepository.fetchForPerson(personId: personId)
             var results: [PersistedDocumentReference] = []
             for record in records {

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Repository/PersonRepository.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Repository/PersonRepository.swift
@@ -154,15 +154,15 @@ final class PersonRepository: PersonRepositoryProtocol, @unchecked Sendable {
     // MARK: - Private Helpers
 
     /// Ensure FMK exists for a person (creates if needed)
-    private func ensureFMK(for personID: String, primaryKey: SymmetricKey) throws -> SymmetricKey {
+    private func ensureFMK(for personId: String, primaryKey: SymmetricKey) throws -> SymmetricKey {
         do {
             // Try to retrieve existing FMK
-            return try fmkService.retrieveFMK(familyMemberID: personID, primaryKey: primaryKey)
+            return try fmkService.retrieveFMK(personId: personId, primaryKey: primaryKey)
         } catch KeychainError.keyNotFound {
             // Generate new FMK for this person
             let fmk = fmkService.generateFMK()
             do {
-                try fmkService.storeFMK(fmk, familyMemberID: personID, primaryKey: primaryKey)
+                try fmkService.storeFMK(fmk, personId: personId, primaryKey: primaryKey)
                 return fmk
             } catch {
                 throw RepositoryError.keyNotAvailable("Failed to store FMK: \(error.localizedDescription)")
@@ -219,7 +219,7 @@ final class PersonRepository: PersonRepositoryProtocol, @unchecked Sendable {
         // Retrieve FMK
         let fmk: SymmetricKey
         do {
-            fmk = try fmkService.retrieveFMK(familyMemberID: id.uuidString, primaryKey: primaryKey)
+            fmk = try fmkService.retrieveFMK(personId: id.uuidString, primaryKey: primaryKey)
         } catch {
             throw RepositoryError
                 .keyNotAvailable("Failed to retrieve FMK for person \(id): \(error.localizedDescription)")

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/ViewModels/Home/PersonDetailViewModel.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/ViewModels/Home/PersonDetailViewModel.swift
@@ -58,7 +58,7 @@ final class PersonDetailViewModel {
         do {
             let primaryKey = try primaryKeyProvider.getPrimaryKey()
             let fmk = try fmkService.retrieveFMK(
-                familyMemberID: person.id.uuidString,
+                personId: person.id.uuidString,
                 primaryKey: primaryKey
             )
 

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/ViewModels/Records/GenericRecordFormViewModel.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/ViewModels/Records/GenericRecordFormViewModel.swift
@@ -245,7 +245,7 @@ final class GenericRecordFormViewModel {
         do {
             let primaryKey = try primaryKeyProvider.getPrimaryKey()
             let fmk = try fmkService.retrieveFMK(
-                familyMemberID: person.id.uuidString,
+                personId: person.id.uuidString,
                 primaryKey: primaryKey
             )
 

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/ViewModels/Records/MedicalRecordListViewModel.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/ViewModels/Records/MedicalRecordListViewModel.swift
@@ -84,7 +84,7 @@ final class MedicalRecordListViewModel {
         do {
             let primaryKey = try primaryKeyProvider.getPrimaryKey()
             let fmk = try fmkService.retrieveFMK(
-                familyMemberID: person.id.uuidString,
+                personId: person.id.uuidString,
                 primaryKey: primaryKey
             )
 
@@ -210,7 +210,7 @@ final class MedicalRecordListViewModel {
         do {
             let primaryKey = try primaryKeyProvider.getPrimaryKey()
             let fmk = try fmkService.retrieveFMK(
-                familyMemberID: person.id.uuidString,
+                personId: person.id.uuidString,
                 primaryKey: primaryKey
             )
             for attachment in attachments {

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Extensions/OptionalStringTrimmingTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Extensions/OptionalStringTrimmingTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+@testable import FamilyMedicalApp
+
+/// Unit tests for `Optional<String>.trimmedNonEmpty()`.
+///
+/// Backup decoders use this helper to normalise `nil` / `""` / whitespace-only
+/// strings to `nil` before constructing model types that distinguish between
+/// "empty" and "absent" values.
+struct OptionalStringTrimmingTests {
+    @Test
+    func trimmedNonEmpty_nilInput_returnsNil() {
+        let value: String? = nil
+        #expect(value.trimmedNonEmpty() == nil)
+    }
+
+    @Test
+    func trimmedNonEmpty_emptyString_returnsNil() {
+        let value: String? = ""
+        #expect(value.trimmedNonEmpty() == nil)
+    }
+
+    @Test
+    func trimmedNonEmpty_whitespaceAndNewlinesOnly_returnsNil() {
+        let value: String? = "  \n\t  \r\n "
+        #expect(value.trimmedNonEmpty() == nil)
+    }
+
+    @Test
+    func trimmedNonEmpty_surroundingWhitespace_returnsTrimmedValue() {
+        let value: String? = "  hello world \n"
+        #expect(value.trimmedNonEmpty() == "hello world")
+    }
+
+    @Test
+    func trimmedNonEmpty_alreadyTrimmed_returnsUnchanged() {
+        let value: String? = "clean"
+        #expect(value.trimmedNonEmpty() == "clean")
+    }
+}

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockFamilyMemberKeyService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockFamilyMemberKeyService.swift
@@ -15,7 +15,7 @@ final class MockFamilyMemberKeyService: FamilyMemberKeyServiceProtocol, @uncheck
 
     // MARK: - Storage
 
-    /// In-memory FMK storage (keyed by family member ID)
+    /// In-memory FMK storage (keyed by person ID)
     var storedFMKs: [String: SymmetricKey] = [:]
 
     // MARK: - Tracking
@@ -63,7 +63,7 @@ final class MockFamilyMemberKeyService: FamilyMemberKeyServiceProtocol, @uncheck
         return SymmetricKey(size: .bits256)
     }
 
-    func storeFMK(_ fmk: SymmetricKey, familyMemberID: String, primaryKey: SymmetricKey) throws {
+    func storeFMK(_ fmk: SymmetricKey, personId: String, primaryKey: SymmetricKey) throws {
         storeCallsCount += 1
 
         if shouldFailStore {
@@ -71,18 +71,18 @@ final class MockFamilyMemberKeyService: FamilyMemberKeyServiceProtocol, @uncheck
         }
 
         // Store in memory
-        storedFMKs[familyMemberID] = fmk
+        storedFMKs[personId] = fmk
     }
 
-    func retrieveFMK(familyMemberID: String, primaryKey: SymmetricKey) throws -> SymmetricKey {
-        retrieveCalls.append((familyMemberID, primaryKey))
+    func retrieveFMK(personId: String, primaryKey: SymmetricKey) throws -> SymmetricKey {
+        retrieveCalls.append((personId, primaryKey))
 
         if shouldFailRetrieve {
             throw KeychainError.retrieveFailed(-1)
         }
 
-        guard let fmk = storedFMKs[familyMemberID] else {
-            throw KeychainError.keyNotFound(familyMemberID)
+        guard let fmk = storedFMKs[personId] else {
+            throw KeychainError.keyNotFound(personId)
         }
 
         return fmk
@@ -105,8 +105,8 @@ final class MockFamilyMemberKeyService: FamilyMemberKeyServiceProtocol, @uncheck
         shouldFailRetrieve = false
     }
 
-    /// Pre-populate an FMK for a family member (for testing retrieval)
-    func setFMK(_ fmk: SymmetricKey, for familyMemberID: String) {
-        storedFMKs[familyMemberID] = fmk
+    /// Pre-populate an FMK for a person (for testing retrieval)
+    func setFMK(_ fmk: SymmetricKey, for personId: String) {
+        storedFMKs[personId] = fmk
     }
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockLoggingService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockLoggingService.swift
@@ -144,10 +144,10 @@ final class MockCategoryLogger: CategoryLoggerProtocol, @unchecked Sendable {
         ))
     }
 
-    func logUserID(_ userID: String) {
+    func logUserId(_ userId: String) {
         capturedEntries.append(CapturedLogEntry(
             level: .debug,
-            message: "userID: \(userID)",
+            message: "userId: \(userId)",
             privacy: .public,
             category: category,
             timestamp: Date()

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Crypto/FamilyMemberKeyServiceTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Crypto/FamilyMemberKeyServiceTests.swift
@@ -66,13 +66,13 @@ struct FamilyMemberKeyServiceTests {
     func storeFMK_persistsToKeychain() throws {
         let fmk = service.generateFMK()
         let primaryKey = SymmetricKey(size: .bits256)
-        let familyMemberID = "test-member-\(UUID().uuidString)"
+        let personId = "test-member-\(UUID().uuidString)"
 
         // Store FMK
-        try service.storeFMK(fmk, familyMemberID: familyMemberID, primaryKey: primaryKey)
+        try service.storeFMK(fmk, personId: personId, primaryKey: primaryKey)
 
         // Verify it exists in Keychain
-        let identifier = "fmk.\(familyMemberID)"
+        let identifier = "fmk.\(personId)"
         #expect(keychainService.keyExists(identifier: identifier))
 
         // Cleanup
@@ -84,13 +84,13 @@ struct FamilyMemberKeyServiceTests {
     func retrieveFMK_withCorrectPrimaryKey() throws {
         let fmk = service.generateFMK()
         let primaryKey = SymmetricKey(size: .bits256)
-        let familyMemberID = "test-retrieve-\(UUID().uuidString)"
+        let personId = "test-retrieve-\(UUID().uuidString)"
 
         // Store FMK
-        try service.storeFMK(fmk, familyMemberID: familyMemberID, primaryKey: primaryKey)
+        try service.storeFMK(fmk, personId: personId, primaryKey: primaryKey)
 
         // Retrieve FMK
-        let retrieved = try service.retrieveFMK(familyMemberID: familyMemberID, primaryKey: primaryKey)
+        let retrieved = try service.retrieveFMK(personId: personId, primaryKey: primaryKey)
 
         // Compare keys
         let originalData = fmk.withUnsafeBytes { Data($0) }
@@ -98,7 +98,7 @@ struct FamilyMemberKeyServiceTests {
         #expect(originalData == retrievedData)
 
         // Cleanup
-        let identifier = "fmk.\(familyMemberID)"
+        let identifier = "fmk.\(personId)"
         try keychainService.deleteKey(identifier: identifier)
     }
 
@@ -108,18 +108,18 @@ struct FamilyMemberKeyServiceTests {
         let fmk = service.generateFMK()
         let correctPrimaryKey = SymmetricKey(size: .bits256)
         let wrongPrimaryKey = SymmetricKey(size: .bits256)
-        let familyMemberID = "test-wrong-key-\(UUID().uuidString)"
+        let personId = "test-wrong-key-\(UUID().uuidString)"
 
         // Store with correct key
-        try service.storeFMK(fmk, familyMemberID: familyMemberID, primaryKey: correctPrimaryKey)
+        try service.storeFMK(fmk, personId: personId, primaryKey: correctPrimaryKey)
 
         // Try to retrieve with wrong key
         #expect(throws: CryptoError.self) {
-            _ = try service.retrieveFMK(familyMemberID: familyMemberID, primaryKey: wrongPrimaryKey)
+            _ = try service.retrieveFMK(personId: personId, primaryKey: wrongPrimaryKey)
         }
 
         // Cleanup
-        let identifier = "fmk.\(familyMemberID)"
+        let identifier = "fmk.\(personId)"
         try keychainService.deleteKey(identifier: identifier)
     }
 
@@ -127,10 +127,10 @@ struct FamilyMemberKeyServiceTests {
     @Test
     func retrieveFMK_nonExistent() throws {
         let primaryKey = SymmetricKey(size: .bits256)
-        let familyMemberID = "non-existent-\(UUID().uuidString)"
+        let personId = "non-existent-\(UUID().uuidString)"
 
         #expect(throws: KeychainError.self) {
-            _ = try service.retrieveFMK(familyMemberID: familyMemberID, primaryKey: primaryKey)
+            _ = try service.retrieveFMK(personId: personId, primaryKey: primaryKey)
         }
     }
 

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Logging/LoggingConvenienceMethodsTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Logging/LoggingConvenienceMethodsTests.swift
@@ -20,11 +20,11 @@ struct LoggingConvenienceMethodsTests {
     }
 
     @Test
-    func logUserIDIsPublic() {
+    func logUserIdIsPublic() {
         let mockLogger = MockCategoryLogger(category: .auth)
         let uuid = "550e8400-e29b-41d4-a716-446655440000"
 
-        mockLogger.logUserID(uuid)
+        mockLogger.logUserId(uuid)
 
         let entries = mockLogger.entriesContaining(uuid)
         #expect(entries.count == 1)

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Logging/LoggingPrivacyTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Logging/LoggingPrivacyTests.swift
@@ -42,7 +42,7 @@ struct LoggingPrivacyTests {
     func hashedPrivacyLevel() {
         let mockLogger = MockCategoryLogger(category: .storage)
 
-        mockLogger.debug("recordID: abc123", privacy: .hashed)
+        mockLogger.debug("recordId: abc123", privacy: .hashed)
 
         let entries = mockLogger.entriesWithPrivacy(.hashed)
         #expect(entries.count == 1)

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Logging/LoggingServiceTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Logging/LoggingServiceTests.swift
@@ -276,12 +276,12 @@ struct LoggingServiceTests {
     }
 
     @Test
-    func realLoggerLogUserID() {
+    func realLoggerLogUserId() {
         let service = LoggingService()
         let logger = service.logger(category: .storage)
 
         // Exercise the real implementation
-        logger.logUserID("user-123")
+        logger.logUserId("user-123")
     }
 
     @Test

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Logging/TracingCategoryLoggerTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Logging/TracingCategoryLoggerTests.swift
@@ -98,7 +98,7 @@ struct TracingCategoryLoggerTests {
         let tracer = TracingCategoryLogger(wrapping: mock)
 
         tracer.logOperation("save", state: "started")
-        tracer.logUserID("user-123")
+        tracer.logUserId("user-123")
         tracer.logRecordCount(5)
         tracer.logTimestamp(Date())
         tracer.logError(NSError(domain: "test", code: 1), context: "TestContext")


### PR DESCRIPTION
## Summary

Final PR in the 4-PR day-1-review cleanup series. Implements findings 21, 22, 23 from `docs/day-1-review/2026-04-18-ready-to-fix.md`.

- **Finding 21** — Consolidate duplicate private `trimmedNonEmpty` helpers in `PersonBackup` and `ProviderBackup` into a shared `Optional<String>.trimmedNonEmpty()` extension (`Extensions/OptionalString+Trimming.swift`), with unit tests.
- **Finding 22** — Rename `personID` / `recordID` / `userID` → `personId` / `recordId` / `userId` across the iOS module. The `logUserID` protocol method becomes `logUserId`; call sites and log-message string literals follow.
- **Finding 23** — Rename `familyMemberID` → `personId` across the `FamilyMemberKeyServiceProtocol` API and all 13 call sites. The `FamilyMemberKeyService` class name and the keychain identifier format (`fmk.<uuid>`) are preserved.

## Behaviour

No behaviour change. Keychain entries written by earlier versions still resolve because the UUID *value* — not the variable name — is what seeds the identifier string.

## Test plan

- [x] `mcp__xcode__BuildProject` — clean build
- [x] `pre-commit run --all-files` — all 22 hooks pass
- [x] `scripts/run-tests.sh` — 1621/1624 passed, 3 skipped, 0 failures (8m 50s)
- [x] `scripts/check-coverage.sh` — 80.74% overall, all per-file thresholds met; new `OptionalString+Trimming.swift` at 100%
- [ ] CI on this PR