### PR TITLE
refactor: remove 5 pieces of dead code (day-1 review PR 1/7)

### DIFF
--- a/docs/coding-practices.md
+++ b/docs/coding-practices.md
@@ -88,7 +88,6 @@ See [ADR-0013](adr/adr-0013-logging-privacy-and-export.md) for full specificatio
 | `.crypto` | Cryptography | Key derivation, encryption, decryption, key management |
 | `.storage` | Data persistence | Core Data operations, record content, schema, attachments |
 | `.backup` | Backup & restore | Export, import, file serialization, schema validation |
-| `.migration` | Schema migration | Migration execution, checkpoints, rollback |
 | `.sync` | Synchronization | Cross-device sync (future) |
 | `.ui` | User interface | View operations, user actions |
 

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Auth/AuthenticationService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Auth/AuthenticationService.swift
@@ -56,9 +56,6 @@ protocol AuthenticationServiceProtocol {
     /// - Throws: AuthenticationError if authentication fails
     func unlockWithBiometric() async throws
 
-    /// Lock the account
-    func lock()
-
     /// Logout and clear all authentication data
     func logout()
 
@@ -295,12 +292,6 @@ final class AuthenticationService: AuthenticationServiceProtocol {
         userDefaults.removeObject(forKey: Self.lockoutEndTimeKey)
 
         logger.logOperation("unlockWithBiometric", state: "success")
-    }
-
-    func lock() {
-        // No-op: Lock state is managed by AuthenticationViewModel.isAuthenticated
-        // This service only manages persistent authentication state (Keychain),
-        // not transient lock state which is handled at the UI layer
     }
 
     func logout() {

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Logging/LogCategory.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Logging/LogCategory.swift
@@ -22,7 +22,4 @@ enum LogCategory: String, CaseIterable {
 
     /// Backup export/import operations
     case backup
-
-    /// Schema migration operations
-    case migration
 }

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Preferences/UserPreferencesService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Preferences/UserPreferencesService.swift
@@ -1,39 +1,12 @@
 import CryptoKit
 import Foundation
 
-/// Protocol for loading, saving, and deleting encrypted user preferences.
-protocol UserPreferencesServiceProtocol: Sendable {
-    /// Load preferences from Keychain, decrypting with the given Primary Key.
-    ///
-    /// Returns default `UserPreferences()` if no stored preferences exist yet.
-    ///
-    /// - Parameter primaryKey: The user's Primary Key for decryption.
-    /// - Returns: Decrypted `UserPreferences`.
-    /// - Throws: `CryptoError` if decryption fails, or a JSON decoding error.
-    func load(primaryKey: SymmetricKey) throws -> UserPreferences
-
-    /// Encrypt and persist preferences to Keychain using the given Primary Key.
-    ///
-    /// - Parameters:
-    ///   - preferences: The preferences to save.
-    ///   - primaryKey: The user's Primary Key for encryption.
-    /// - Throws: `CryptoError` if encryption fails, or a JSON encoding / Keychain error.
-    func save(_ preferences: UserPreferences, primaryKey: SymmetricKey) throws
-
-    /// Remove stored preferences from Keychain.
-    ///
-    /// Safe to call even when no preferences are currently stored.
-    ///
-    /// - Throws: `KeychainError` on unexpected Keychain failure.
-    func delete() throws
-}
-
 /// Encrypts `UserPreferences` with the user's Primary Key and stores the
 /// result as a single combined blob in the Keychain.
 ///
 /// Key rotation is the caller's responsibility: re-save with the new Primary
 /// Key after rotation; this service only encrypts / decrypts.
-final class UserPreferencesService: UserPreferencesServiceProtocol, @unchecked Sendable {
+final class UserPreferencesService: @unchecked Sendable {
     // MARK: - Constants
 
     private static let keychainIdentifier = "user_preferences"
@@ -57,8 +30,6 @@ final class UserPreferencesService: UserPreferencesServiceProtocol, @unchecked S
             wrapping: logger ?? LoggingService.shared.logger(category: .storage)
         )
     }
-
-    // MARK: - UserPreferencesServiceProtocol
 
     func load(primaryKey: SymmetricKey) throws -> UserPreferences {
         let start = ContinuousClock.now

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Schema/RecordTypeRegistry.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Schema/RecordTypeRegistry.swift
@@ -1,13 +1,5 @@
 import Foundation
 
-/// Protocol for record type metadata access
-protocol RecordTypeRegistryProtocol: Sendable {
-    func displayName(for recordType: RecordType) -> String
-    func iconSystemName(for recordType: RecordType) -> String
-    func fieldMetadata(for recordType: RecordType) -> [FieldMetadata]
-    var allRecordTypes: [RecordType] { get }
-}
-
 /// Simple registry that returns static metadata from record type structs.
 /// Replaces the old SchemaService which fetched per-person encrypted schemas.
 ///
@@ -15,7 +7,7 @@ protocol RecordTypeRegistryProtocol: Sendable {
 /// the `RecordType` extension, and `fieldMetadata` switches on `RecordType`
 /// directly. Adding a new `RecordType` case is a compile error until every
 /// switch is updated, so there are no silent-fallback or runtime-crash paths.
-final class RecordTypeRegistry: RecordTypeRegistryProtocol, Sendable {
+final class RecordTypeRegistry: Sendable {
     var allRecordTypes: [RecordType] {
         RecordType.allCases
     }

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Utilities/UITestingHelpers.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Utilities/UITestingHelpers.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftUI
 
 /// Helper for detecting if the app is running in UI testing mode
 enum UITestingHelpers {

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Utilities/UITestingHelpers.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Utilities/UITestingHelpers.swift
@@ -24,20 +24,3 @@ enum UITestingHelpers {
         isUITesting && CommandLine.arguments.contains("--use-demo-mode")
     }
 }
-
-// MARK: - View Extension
-
-extension View {
-    /// Conditionally applies textContentType only when NOT in UI testing mode
-    /// This prevents password autofill prompts from blocking XCUITest automation
-    @ViewBuilder
-    func textContentTypeIfNotTesting(_ contentType: UITextContentType?) -> some View {
-        if UITestingHelpers.isUITesting {
-            // In UI testing mode: don't apply textContentType to avoid autofill prompts
-            self
-        } else {
-            // In production: apply textContentType for proper password manager support
-            self.textContentType(contentType)
-        }
-    }
-}

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockServices.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Mocks/MockServices.swift
@@ -111,10 +111,6 @@ final class MockAuthenticationService: AuthenticationServiceProtocol {
         }
     }
 
-    func lock() {
-        // No-op for mock
-    }
-
     func enableBiometric() async throws {
         if let biometricService {
             try await biometricService.authenticate(reason: "Enable biometric")

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Logging/LoggingServiceTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Services/Logging/LoggingServiceTests.swift
@@ -147,14 +147,13 @@ struct LoggingServiceTests {
     @Test
     func logCategoryHasAllCases() {
         let categories = LogCategory.allCases
-        #expect(categories.count == 7)
+        #expect(categories.count == 6)
         #expect(categories.contains(.auth))
         #expect(categories.contains(.crypto))
         #expect(categories.contains(.storage))
         #expect(categories.contains(.sync))
         #expect(categories.contains(.ui))
         #expect(categories.contains(.backup))
-        #expect(categories.contains(.migration))
     }
 
     // MARK: - Real CategoryLogger Tests

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/ViewModels/Auth/AuthenticationViewModelAccountExistsTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/ViewModels/Auth/AuthenticationViewModelAccountExistsTests.swift
@@ -171,7 +171,6 @@ private final class MockAuthenticationServiceWithAccountExists: AuthenticationSe
     }
 
     func unlockWithBiometric() async throws {}
-    func lock() {}
     func logout() {
         isSetUp = false
     }


### PR DESCRIPTION
## Summary

Pure deletion of five self-contained pieces of dead code surfaced in the 2026-04-18 day-1 review. No behaviour change. Each commit is independently revertable.

References: `docs/day-1-review/2026-04-18-detailed-report.md` findings **#2, #3, #4, #7, #28**.

## Changes

| Finding | Symbol | Files | Rationale |
|---|---|---|---|
| #2 | `View.textContentTypeIfNotTesting(_:)` | `Utilities/UITestingHelpers.swift` | Zero callers; auth views use inline `UITestingHelpers.isUITesting` checks instead. Also drops the now-orphan `import SwiftUI` (follow-up commit `492bb28`). |
| #3 | `UserPreferencesServiceProtocol` | `Services/Preferences/UserPreferencesService.swift` | Zero external consumers; no mocks. YAGNI — concrete class is enough. |
| #4 | `RecordTypeRegistryProtocol` | `Services/Schema/RecordTypeRegistry.swift` | Zero external consumers; no mocks. |
| #7 | `AuthenticationService.lock()` no-op | `Services/Auth/AuthenticationService.swift`, `Mocks/MockServices.swift`, `ViewModels/Auth/AuthenticationViewModelAccountExistsTests.swift` | Empty body documented as "Lock state is managed by `AuthenticationViewModel`"; zero production callers. The real lock paths (`LockStateService.lock()`, `AuthenticationViewModel.lock()`) are untouched. |
| #28 | `LogCategory.migration` orphan case | `Services/Logging/LogCategory.swift`, `LoggingServiceTests.swift`, `docs/coding-practices.md` | Zero production callers; fossil from pre-ADR-0009 schema migration work. |

## Test plan

- [x] Pre-commit (`pre-commit run --all-files`) — all hooks pass (SwiftFormat, SwiftLint, markdownlint, shellcheck, etc.)
- [x] Full iOS test suite (`scripts/run-tests.sh`) — passes locally (exit 0); CI re-validating
- [x] Coverage (`scripts/check-coverage.sh`) — overall 80.77% ≥ 80%; all per-file thresholds met
- [x] Targeted suites run after each deletion (`UserPreferencesServiceTests`, `RecordTypeRegistryTests`, `AuthenticationServiceTests`, `LoggingServiceTests`) — all pass

## Follow-ups (out of scope for this PR)

1. **Trade-off note** (not a defect): `UserPreferencesService` no longer conforms to any protocol. Consistent with the YAGNI rationale — but if a future test ever needs to mock the service, the protocol will need to be re-added. `EncryptionServiceProtocol` / `KeychainServiceProtocol` (both still injected into this service) set the pattern.

## Part of

Day-1 review clean-up — this is PR 1 of 7 planned PRs addressing the findings in `docs/day-1-review/2026-04-18-detailed-report.md`. Plan: `docs/day-1-review/plans/2026-04-18-pr1-dead-code-removal.md`.