### PR TITLE
docs + scripts: PR #181 follow-ups (run-tests.sh, SETUP.md Backend, ADR-0009)

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -259,15 +259,29 @@ Recommended Swift/SwiftUI tutorials (1-2 hours total):
 - Test different iPhone/iPad models
 - Simulate Face ID, location, etc.
 
-## Backend Development (Phase 2)
+## Backend Development
 
-When we reach Phase 2 (sync backend), we'll add:
+The backend lives at `backend-rust/` — a Rust [Cloudflare Worker](https://developers.cloudflare.com/workers/) that terminates the OPAQUE authentication protocol. It is deployed via `wrangler` to `api.recordwell.app/auth/opaque/*` and uses Cloudflare KV for credential envelopes, cipher bundles, and transient login state.
 
-- **Devcontainer** for backend API (Python FastAPI likely)
-- **Docker Compose** for local database
-- Backend can be developed in VS Code while iOS in Xcode
+### Prerequisites
 
-Configuration will be added in Phase 2 issues.
+- **Rust** (stable): `brew install rustup && rustup-init`, then `rustup default stable`.
+- **wrangler** (Cloudflare Workers CLI): `brew install wrangler` or `npm install -g wrangler`.
+- **worker-build** (installed automatically by `wrangler dev` / `wrangler deploy` via the `[build]` hook in `backend-rust/wrangler.toml`).
+
+### Local development
+
+```bash
+cd backend-rust
+wrangler dev           # local Worker runtime with hot reload
+cargo test             # Rust unit + integration tests
+```
+
+Authentication against the local Worker requires `api.recordwell.app` resolve somewhere — point the iOS app at the dev URL via the `baseURL:` init parameter on `OpaqueAuthService` (no xcconfig override exists today; see `OpaqueAuthService.swift:25-33`).
+
+### Deployment
+
+Production deploy is triggered by `wrangler deploy` from `backend-rust/`; routes and KV namespace bindings are pinned in `wrangler.toml`. PR-preview deployments use `--name recordwell-opaque-pr-N`.
 
 ## Verification
 

--- a/docs/adr/adr-0009-schema-evolution-multi-master.md
+++ b/docs/adr/adr-0009-schema-evolution-multi-master.md
@@ -36,11 +36,15 @@ Field IDs are auto-generated UUIDs, not user-provided strings. `displayName` bec
 
 ### 2. Hybrid Logical Clock for Versions
 
+*(Never implemented — see Superseded banner above.)*
+
 Replace sequential `version: Int` with `(timestamp, deviceId, counter)` tuple.
 
 **Rationale**: Sequential integers collide when two devices independently create the same version number. The hybrid clock ensures **uniqueness** - no two versions can ever be identical. Ordering is secondary; the primary goal is collision avoidance.
 
 ### 3. Schema Merge is Trivial (Set Union)
+
+*(Never implemented — see Superseded banner above.)*
 
 Schema merge is just a set union by field UUID:
 
@@ -50,6 +54,8 @@ Schema merge is just a set union by field UUID:
 **Rationale**: With UUID-based field IDs, there are no structural conflicts. Two devices adding fields independently just results in more fields. The only "conflict" is when the same field (same UUID) has different metadata (displayName, etc.) - ask user to pick.
 
 ### 4. Field Visibility State
+
+*(Never implemented — see Superseded banner above.)*
 
 Fields have visibility: `.active`, `.hidden`, `.deprecated`. Hidden fields keep their data in records.
 

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -94,7 +94,15 @@ if ! [[ "$LIMIT" =~ ^[0-9]+$ ]]; then
 fi
 
 # Apply default destination if not set
-DESTINATION="${DESTINATION:-platform=iOS Simulator,name=iPhone 17,OS=26.2}"
+# CI runners are ephemeral (fresh VM per run), so name= destinations are safe there.
+# Local / long-running machines retain ~/Library/Developer/XCTestDevices/ across invocations,
+# where name= clones a new ~16GB simulator each time (see AGENTS.md). Require an explicit
+# UUID-based DESTINATION there to prevent the storage bomb.
+if [[ -n "${CI:-}" ]] || [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+    DESTINATION="${DESTINATION:-platform=iOS Simulator,name=iPhone 17,OS=26.2}"
+else
+    : "${DESTINATION:?must be set locally — see AGENTS.md for the UUID-lookup pattern}"
+fi
 
 # Capture start time for duration tracking
 START_TIME=$(date +%s)


### PR DESCRIPTION
## Summary

Three follow-ups identified during review of PR #181 (day-1 review PR 2). Each addresses a defect/inconsistency that was flagged as out-of-scope at the time and recorded under "Follow-ups" in the PR #181 body.

- **`scripts/run-tests.sh`** — unconditional `DESTINATION=...,name=iPhone 17,OS=26.2` default tripped the storage-bomb AGENTS.md warns about when developers ran it locally without overriding. Now gated on `$CI` / `$GITHUB_ACTIONS`: CI runners (ephemeral VMs) keep the `name=` default; local invocations must provide `$DESTINATION`, with a pointer to AGENTS.md for the UUID-lookup pattern.
- **`SETUP.md` Backend section** — previously promised a "Phase 2" Python FastAPI + Docker Compose stack that never happened. Rewritten to describe the actual backend (`backend-rust/`, Rust Cloudflare Worker terminating OPAQUE, deployed via `wrangler` to `api.recordwell.app/auth/opaque/*`). Names prerequisites (rustup, wrangler) and points at `OpaqueAuthService.swift:25-33` for the local-to-prod wiring path.
- **ADR-0009 Decision sections 2-4** — ADR-0009 is Superseded (by FHIR-based typed records), but its Decision sections sit 40+ lines from the Superseded banner. A scanner landing in "### 2. Hybrid Logical Clock for Versions" could read aspirational design as shipped behaviour. Added a single-line "(Never implemented — see Superseded banner above.)" callout under sections 2 (Hybrid Logical Clock), 3 (Schema Merge is Trivial), and 4 (Field Visibility State). Sections 1 (UUID-Based Field IDs) and 5 (Device Identity for Provenance) did ship and are left alone.

## Verification

**`run-tests.sh` behaviour verified via isolated bash test harness (three paths):**

```bash
# Path 1: local + unset DESTINATION → helpful error
$ bash -c '<new block>; echo OK'
bash: line 5: DESTINATION: must be set locally — see AGENTS.md for the UUID-lookup pattern
# Exit 127 ✓

# Path 2: CI=1 + unset DESTINATION → default applied
$ CI=1 bash -c '<new block>; echo OK: $DESTINATION'
OK: DESTINATION=platform=iOS Simulator,name=iPhone 17,OS=26.2  ✓

# Path 3: local + explicit UUID DESTINATION → passes through
$ DESTINATION="platform=iOS Simulator,id=..." bash -c '<new block>; echo OK: $DESTINATION'
OK: DESTINATION=platform=iOS Simulator,id=...  ✓
```

**CI invocation path verified:** `.github/workflows/ios-ci.yml:187` calls `./scripts/run-tests.sh --destination "${{ matrix.destination }}"`, which sets `$DESTINATION` before the new check. Combined with `$GITHUB_ACTIONS=true` on runners, CI is doubly covered.

## Test plan

- [x] \`pre-commit run --all-files\` — all 22 hooks green (shellcheck passed on modified script, markdownlint passed on SETUP.md and ADR)
- [x] Shell-script behaviour verified in three paths (above)
- [ ] CI will run the full iOS suite on this PR — no iOS source touched, but the test runner script itself changed, so green CI is the authoritative signal.

## Commits

- 856738f — scripts: require explicit DESTINATION locally, keep CI default
- 5703dfa — docs: rewrite SETUP.md Backend section for backend-rust / Cloudflare Workers
- 131bd80 — docs(adr-0009): flag Decision sections 2-4 as never implemented

## Summary by Sourcery

Document backend architecture updates and tighten test runner defaults for safer local use.

Bug Fixes:
- Guard iOS test runner default destination to avoid creating excessive local simulators while preserving CI behavior.

Enhancements:
- Rewrite backend setup docs to describe the current Rust Cloudflare Worker implementation and its development/deployment workflow.
- Clarify that certain previously described schema evolution ADR decisions were never implemented to prevent misinterpretation.