### PR TITLE
docs: document hidden defaults (rate-limit, TTL, CORS, KDF, session) (day-1 review PR 4/7)

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -275,10 +275,11 @@ The backend lives at `backend-rust/` — a Rust [Cloudflare Worker](https://deve
 cd backend-rust
 wrangler dev                                 # local Worker runtime with hot reload
 cargo build --target wasm32-unknown-unknown  # build verification
-./tests/smoke_test.sh http://localhost:8787  # integration smoke against wrangler dev
+cargo test                                   # native unit + integration tests
+./tests/smoke_test.sh http://localhost:8787  # deploy-time smoke against wrangler dev
 ```
 
-`backend-rust/.cargo/config.toml` pins the build target to `wasm32-unknown-unknown`, so `cargo test` cannot run natively — the backend does not have native-runnable unit tests today. `tests/smoke_test.sh` is the integration test harness (CI runs it against each preview deploy); point it at any live `BASE_URL`, defaulting to `https://api.recordwell.app` when omitted.
+`cargo test` runs against the host triple for unit and integration coverage; `backend-rust/.cargo/config.toml` only scopes the `+simd128` rustflag to `wasm32-unknown-unknown` builds, leaving the host target free. `tests/smoke_test.sh` remains the deploy-time regression harness (CI runs it against each preview deploy); point it at any live `BASE_URL`, defaulting to `https://api.recordwell.app` when omitted.
 
 Authentication against the local Worker requires `api.recordwell.app` resolve somewhere — point the iOS app at the dev URL via the `baseURL:` init parameter on `OpaqueAuthService` (no xcconfig override exists today; see `defaultBaseURL` in `ios/FamilyMedicalApp/FamilyMedicalApp/Services/Auth/OpaqueAuthService.swift` for the hardcoded production endpoint).
 

--- a/backend-rust/.cargo/config.toml
+++ b/backend-rust/.cargo/config.toml
@@ -1,5 +1,2 @@
-[build]
-target = "wasm32-unknown-unknown"
-
 [target.wasm32-unknown-unknown]
 rustflags = ["-C", "target-feature=+simd128"]

--- a/backend-rust/Cargo.toml
+++ b/backend-rust/Cargo.toml
@@ -5,7 +5,21 @@ edition = "2021"
 description = "OPAQUE authentication worker for RecordWell"
 
 [lib]
-crate-type = ["cdylib"]
+# `cdylib` is required for the wasm worker build; `rlib` is required so
+# integration tests in `tests/` can link against the library and exercise
+# modules gated behind the `testing` feature (see `tests/rate_limit_error_logging_test.rs`).
+crate-type = ["cdylib", "rlib"]
+
+[features]
+# Exposes internal test hooks (`__test_hooks` module) so integration tests in
+# `tests/` can drive `check_rate_limit_inner` with a fake KV store. NOT enabled
+# in release builds and NOT part of the public API. Integration tests that
+# need it declare `required-features = ["testing"]` in `[[test]]` below.
+testing = []
+
+[[test]]
+name = "rate_limit_error_logging_test"
+required-features = ["testing"]
 
 [dependencies]
 worker = "0.7"

--- a/backend-rust/Cargo.toml
+++ b/backend-rust/Cargo.toml
@@ -11,10 +11,11 @@ description = "OPAQUE authentication worker for RecordWell"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-# Exposes internal test hooks (`__test_hooks` module) so integration tests in
-# `tests/` can drive `check_rate_limit_inner` with a fake KV store. NOT enabled
-# in release builds and NOT part of the public API. Integration tests that
-# need it declare `required-features = ["testing"]` in `[[test]]` below.
+# Exposes `rate_limit` as `pub mod` (see `src/lib.rs`) so integration tests in
+# `tests/` can link against `check_rate_limit_inner`, `RateLimitStore`, and the
+# related types. NOT enabled in release builds — the wasm worker's public API
+# is unchanged. Integration tests that need it declare
+# `required-features = ["testing"]` in `[[test]]` below.
 testing = []
 
 [[test]]

--- a/backend-rust/src/lib.rs
+++ b/backend-rust/src/lib.rs
@@ -1,6 +1,16 @@
 mod opaque;
-mod rate_limit;
 mod routes;
+
+// `rate_limit` is private in release builds and exposed only when the
+// `testing` feature is enabled, so the integration test in
+// `tests/rate_limit_error_logging_test.rs` can reach
+// `check_rate_limit_inner` and the `RateLimitStore` trait without making
+// them part of the worker's release-build public API. See
+// `backend-rust/Cargo.toml` for the feature wiring.
+#[cfg(not(feature = "testing"))]
+mod rate_limit;
+#[cfg(feature = "testing")]
+pub mod rate_limit;
 
 use serde::Serialize;
 use std::collections::HashMap;

--- a/backend-rust/src/lib.rs
+++ b/backend-rust/src/lib.rs
@@ -6,6 +6,14 @@ use serde::Serialize;
 use std::collections::HashMap;
 use worker::*;
 
+/// Preflight cache duration for CORS `Access-Control-Max-Age`.
+/// 24h is the maximum browsers typically honour. Because the OPAQUE
+/// auth wire contract is still iterating (see ADR-0011), reviewers
+/// should lower this if a breaking change to allowed headers ever
+/// ships, since browsers will hold stale permissions up to the cache
+/// duration.
+const CORS_PREFLIGHT_MAX_AGE_SECONDS: u32 = 86400;
+
 #[derive(Serialize)]
 struct HealthStatus {
     status: &'static str,
@@ -99,10 +107,11 @@ async fn handle_ready(env: &Env) -> Result<Response> {
 }
 
 fn cors_preflight() -> Result<Response> {
+    let max_age = CORS_PREFLIGHT_MAX_AGE_SECONDS.to_string();
     let headers = routes::build_response_headers(&[
         ("Access-Control-Allow-Methods", "GET, POST, OPTIONS"),
         ("Access-Control-Allow-Headers", "Content-Type"),
-        ("Access-Control-Max-Age", "86400"),
+        ("Access-Control-Max-Age", &max_age),
     ])?;
     Ok(Response::empty()?.with_headers(headers))
 }

--- a/backend-rust/src/rate_limit.rs
+++ b/backend-rust/src/rate_limit.rs
@@ -58,6 +58,15 @@ pub struct RateLimitEntry {
     window_start: u64,
 }
 
+#[cfg(feature = "testing")]
+impl RateLimitEntry {
+    /// Test-only constructor so integration tests can script a `Found(entry)`
+    /// read into the fake KV store. Not compiled into the release worker.
+    pub fn new_for_testing(count: u32, window_start: u64) -> Self {
+        Self { count, window_start }
+    }
+}
+
 /// Outcome of a single `check_rate_limit_inner` invocation.
 ///
 /// `decision` drives the control-flow response to the caller. `diagnostics`
@@ -68,21 +77,18 @@ pub struct RateLimitEntry {
 pub struct RateLimitOutcome {
     /// `None` = allow, `Some(retry_after_secs)` = deny.
     pub decision: Option<u64>,
-    /// Zero or more observability events from this check.
-    pub diagnostics: Vec<RateLimitDiagnostic>,
+    /// Zero or more failures observed during this check.
+    pub diagnostics: Vec<RateLimitFailure>,
 }
 
 /// A KV-layer failure observed while checking the rate limit.
 ///
 /// These are emitted as distinct log lines so operators can alert on
 /// each independently. See ADR-0011 §"Rate-limiter fail-open policy and
-/// alerting contract" for the alerting thresholds.
-///
-/// Variants drop the `Error` suffix (per clippy::enum_variant_names) —
-/// the enum name already communicates "failure observation". The `Counter`
-/// doc line pins the externally-observable name emitted to logs.
+/// alerting contract" for the alerting thresholds. The `Counter` doc line
+/// on each variant pins the externally-observable name emitted to logs.
 #[derive(Debug, PartialEq, Eq)]
-pub enum RateLimitDiagnostic {
+pub enum RateLimitFailure {
     /// KV `get` returned a transport error. Transient Cloudflare infra failure.
     /// Counter: `rate_limit_kv_get_error`. Severity: warn.
     KvGet { key: String, err: String },
@@ -184,20 +190,20 @@ pub async fn check_rate_limit_inner<S: RateLimitStore>(
     now: u64,
     config: &RateLimitConfig,
 ) -> RateLimitOutcome {
-    let mut diagnostics: Vec<RateLimitDiagnostic> = Vec::new();
+    let mut diagnostics: Vec<RateLimitFailure> = Vec::new();
 
     let existing: Option<RateLimitEntry> = match store.get_entry(key).await {
         Ok(GetEntryResult::Found(entry)) => Some(entry),
         Ok(GetEntryResult::Missing) => None,
         Ok(GetEntryResult::Undeserializable(err)) => {
-            diagnostics.push(RateLimitDiagnostic::Deser {
+            diagnostics.push(RateLimitFailure::Deser {
                 key: key.to_string(),
                 err,
             });
             None
         }
         Err(err) => {
-            diagnostics.push(RateLimitDiagnostic::KvGet {
+            diagnostics.push(RateLimitFailure::KvGet {
                 key: key.to_string(),
                 err,
             });
@@ -230,7 +236,7 @@ pub async fn check_rate_limit_inner<S: RateLimitStore>(
     };
 
     if let Err(err) = store.put_entry(key, &next_entry, config.window_seconds).await {
-        diagnostics.push(RateLimitDiagnostic::KvPut {
+        diagnostics.push(RateLimitFailure::KvPut {
             key: key.to_string(),
             err,
         });
@@ -241,23 +247,23 @@ pub async fn check_rate_limit_inner<S: RateLimitStore>(
 
 /// Translate a diagnostic into a `console_*!` log line. The `counter=` prefix
 /// is load-bearing: ops dashboards grep for it to build per-counter alerts.
-fn emit_diagnostic(diag: &RateLimitDiagnostic) {
+fn emit_diagnostic(diag: &RateLimitFailure) {
     match diag {
-        RateLimitDiagnostic::KvGet { key, err } => {
+        RateLimitFailure::KvGet { key, err } => {
             console_warn!(
                 "[rate_limit] counter=rate_limit_kv_get_error key={} err={} (fail-open)",
                 key,
                 err
             );
         }
-        RateLimitDiagnostic::Deser { key, err } => {
+        RateLimitFailure::Deser { key, err } => {
             console_error!(
-                "[rate_limit] counter=rate_limit_deser_error key={} err={} (overwriting on next write)",
+                "[rate_limit] counter=rate_limit_deser_error key={} err={} (overwriting with fresh window)",
                 key,
                 err
             );
         }
-        RateLimitDiagnostic::KvPut { key, err } => {
+        RateLimitFailure::KvPut { key, err } => {
             console_warn!(
                 "[rate_limit] counter=rate_limit_kv_put_error key={} err={} (fail-open)",
                 key,

--- a/backend-rust/src/rate_limit.rs
+++ b/backend-rust/src/rate_limit.rs
@@ -2,6 +2,23 @@
 //!
 //! Uses Cloudflare KV with sliding window algorithm.
 //! Keys: `rate:{client_identifier}:{endpoint}` with TTL-based expiry.
+//!
+//! ## Fail-open policy
+//!
+//! This module fails open on every KV error (get failure, deserialization
+//! failure, put failure). Rationale + alerting contract are documented in
+//! `docs/adr/adr-0011-opaque-zero-knowledge-auth.md` §"Rate-limiter
+//! fail-open policy and alerting contract". The three failure modes are
+//! emitted as distinct log lines with a `counter=` prefix so operators can
+//! wire up separate alerts for transient KV outages vs. deserialization
+//! errors (schema drift / poisoning).
+//!
+//! ## Visibility
+//!
+//! The module is `pub` only when the `testing` feature is enabled (see
+//! `src/lib.rs`), so the items below marked `pub` are *not* part of the
+//! release-build public API — they are only reachable from the integration
+//! test in `tests/rate_limit_error_logging_test.rs`.
 
 use serde::{Deserialize, Serialize};
 use worker::*;
@@ -34,11 +51,101 @@ impl Default for RateLimitConfig {
     }
 }
 
-/// Rate limit entry stored in KV
-#[derive(Serialize, Deserialize)]
-struct RateLimitEntry {
+/// Rate limit entry stored in KV.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RateLimitEntry {
     count: u32,
     window_start: u64,
+}
+
+/// Outcome of a single `check_rate_limit_inner` invocation.
+///
+/// `decision` drives the control-flow response to the caller. `diagnostics`
+/// enumerates any KV-level failures observed during the check so the outer
+/// wrapper can emit one log line per failure, each tagged with a distinct
+/// `counter=` value for alerting.
+#[derive(Debug, PartialEq, Eq)]
+pub struct RateLimitOutcome {
+    /// `None` = allow, `Some(retry_after_secs)` = deny.
+    pub decision: Option<u64>,
+    /// Zero or more observability events from this check.
+    pub diagnostics: Vec<RateLimitDiagnostic>,
+}
+
+/// A KV-layer failure observed while checking the rate limit.
+///
+/// These are emitted as distinct log lines so operators can alert on
+/// each independently. See ADR-0011 §"Rate-limiter fail-open policy and
+/// alerting contract" for the alerting thresholds.
+///
+/// Variants drop the `Error` suffix (per clippy::enum_variant_names) —
+/// the enum name already communicates "failure observation". The `Counter`
+/// doc line pins the externally-observable name emitted to logs.
+#[derive(Debug, PartialEq, Eq)]
+pub enum RateLimitDiagnostic {
+    /// KV `get` returned a transport error. Transient Cloudflare infra failure.
+    /// Counter: `rate_limit_kv_get_error`. Severity: warn.
+    KvGet { key: String, err: String },
+    /// Stored bytes failed to deserialize. Schema drift or poisoning.
+    /// Counter: `rate_limit_deser_error`. Severity: error.
+    Deser { key: String, err: String },
+    /// KV `put` returned a transport error. Transient Cloudflare infra failure.
+    /// Counter: `rate_limit_kv_put_error`. Severity: warn.
+    KvPut { key: String, err: String },
+}
+
+/// Minimal abstraction over the KV operations the rate limiter needs.
+///
+/// Exists solely so the core logic in [`check_rate_limit_inner`] can be
+/// exercised natively (the real `worker::kv::KvStore` is a wasm-only
+/// wrapper around a JS object). There is exactly one production impl
+/// (`&kv::KvStore`, below) and one test impl (in
+/// `tests/rate_limit_error_logging_test.rs`).
+///
+/// Cloudflare Workers are single-threaded per isolate, so we don't need
+/// `Send` bounds on the returned futures — hence `async fn` directly.
+#[allow(async_fn_in_trait)]
+pub trait RateLimitStore {
+    async fn get_entry(&self, key: &str) -> std::result::Result<GetEntryResult, String>;
+    async fn put_entry(&self, key: &str, entry: &RateLimitEntry, ttl_seconds: u64) -> std::result::Result<(), String>;
+}
+
+/// Result of a rate-limit `get` attempt, separating "absent" from
+/// "present-but-undeserializable" so the caller can emit distinct counters.
+pub enum GetEntryResult {
+    /// Key absent — start a fresh window.
+    Missing,
+    /// Key present and parsed successfully.
+    Found(RateLimitEntry),
+    /// Key present but bytes failed to deserialize. The stored string is
+    /// elided (too large to log); only the error is surfaced. Named
+    /// `Undeserializable` rather than `DeserError` to satisfy
+    /// `clippy::enum_variant_names` (the sibling `Missing`/`Found` variants
+    /// are non-error states).
+    Undeserializable(String),
+}
+
+impl RateLimitStore for &kv::KvStore {
+    async fn get_entry(&self, key: &str) -> std::result::Result<GetEntryResult, String> {
+        match self.get(key).text().await {
+            Ok(Some(text)) => match serde_json::from_str::<RateLimitEntry>(&text) {
+                Ok(entry) => Ok(GetEntryResult::Found(entry)),
+                Err(err) => Ok(GetEntryResult::Undeserializable(err.to_string())),
+            },
+            Ok(None) => Ok(GetEntryResult::Missing),
+            Err(err) => Err(err.to_string()),
+        }
+    }
+
+    async fn put_entry(&self, key: &str, entry: &RateLimitEntry, ttl_seconds: u64) -> std::result::Result<(), String> {
+        let payload = serde_json::to_string(entry).map_err(|e| e.to_string())?;
+        let builder = self.put(key, payload).map_err(|e| e.to_string())?;
+        builder
+            .expiration_ttl(ttl_seconds)
+            .execute()
+            .await
+            .map_err(|e| e.to_string())
+    }
 }
 
 /// Check and update rate limit for a client identifier + endpoint combination.
@@ -47,6 +154,8 @@ struct RateLimitEntry {
 /// Note: The read-then-write pattern has a race condition, but this is acceptable because:
 /// 1. This is defense-in-depth (Cloudflare edge rate limiting is the primary mechanism)
 /// 2. Cloudflare KV has eventual consistency anyway
+///
+/// Fail-open on KV errors: see module-level docs and ADR-0011.
 pub async fn check_rate_limit(
     kv: &kv::KvStore,
     client_identifier: &str,
@@ -55,47 +164,105 @@ pub async fn check_rate_limit(
 ) -> std::result::Result<(), u64> {
     let key = format!("rate:{}:{}", client_identifier, endpoint);
     let now = Date::now().as_millis() / 1000; // seconds since epoch
-
-    // Get existing entry
-    let entry: Option<RateLimitEntry> = kv.get(&key).json().await.unwrap_or_default();
-
-    match entry {
-        Some(mut e) if now < e.window_start + config.window_seconds => {
-            // Within window
-            if e.count >= config.max_requests {
-                // Rate limited - return seconds until window expires
-                let remaining = (e.window_start + config.window_seconds) - now;
-                return Err(remaining);
-            }
-            // Increment count
-            e.count += 1;
-            if let Ok(builder) = kv.put(&key, serde_json::to_string(&e).unwrap_or_default()) {
-                if builder.expiration_ttl(config.window_seconds).execute().await.is_err() {
-                    // Fail-open: log but allow request (primary rate limiting is at Cloudflare edge)
-                    console_log!("[rate_limit] KV write failed for key: {}", key);
-                }
-            }
-            Ok(())
-        }
-        _ => {
-            // No entry or window expired - start new window
-            let new_entry = RateLimitEntry {
-                count: 1,
-                window_start: now,
-            };
-            if let Ok(builder) = kv.put(&key, serde_json::to_string(&new_entry).unwrap_or_default()) {
-                if builder.expiration_ttl(config.window_seconds).execute().await.is_err() {
-                    // Fail-open: log but allow request (primary rate limiting is at Cloudflare edge)
-                    console_log!("[rate_limit] KV write failed for key: {}", key);
-                }
-            }
-            Ok(())
-        }
+    let outcome = check_rate_limit_inner(&kv, &key, now, config).await;
+    for diag in &outcome.diagnostics {
+        emit_diagnostic(diag);
+    }
+    match outcome.decision {
+        Some(retry_after) => Err(retry_after),
+        None => Ok(()),
     }
 }
 
-#[cfg(test)]
-mod tests {
-    // Note: KV tests require wrangler dev or miniflare
-    // Unit tests focus on serialization logic
+/// Pure-ish core logic of [`check_rate_limit`]: takes an injectable store
+/// and an explicit `now`, returns an outcome describing both the decision
+/// and any KV failures that occurred. Separated from [`check_rate_limit`]
+/// so it can be tested natively with a fake store.
+pub async fn check_rate_limit_inner<S: RateLimitStore>(
+    store: &S,
+    key: &str,
+    now: u64,
+    config: &RateLimitConfig,
+) -> RateLimitOutcome {
+    let mut diagnostics: Vec<RateLimitDiagnostic> = Vec::new();
+
+    let existing: Option<RateLimitEntry> = match store.get_entry(key).await {
+        Ok(GetEntryResult::Found(entry)) => Some(entry),
+        Ok(GetEntryResult::Missing) => None,
+        Ok(GetEntryResult::Undeserializable(err)) => {
+            diagnostics.push(RateLimitDiagnostic::Deser {
+                key: key.to_string(),
+                err,
+            });
+            None
+        }
+        Err(err) => {
+            diagnostics.push(RateLimitDiagnostic::KvGet {
+                key: key.to_string(),
+                err,
+            });
+            None
+        }
+    };
+
+    let (next_entry, decision) = match existing {
+        Some(mut e) if now < e.window_start + config.window_seconds => {
+            // Within window
+            if e.count >= config.max_requests {
+                // Rate limited - no write, return seconds until window expires
+                let remaining = (e.window_start + config.window_seconds) - now;
+                return RateLimitOutcome {
+                    decision: Some(remaining),
+                    diagnostics,
+                };
+            }
+            e.count += 1;
+            (e, None)
+        }
+        _ => {
+            // No entry, window expired, or prior entry unusable - start a fresh window.
+            let fresh = RateLimitEntry {
+                count: 1,
+                window_start: now,
+            };
+            (fresh, None)
+        }
+    };
+
+    if let Err(err) = store.put_entry(key, &next_entry, config.window_seconds).await {
+        diagnostics.push(RateLimitDiagnostic::KvPut {
+            key: key.to_string(),
+            err,
+        });
+    }
+
+    RateLimitOutcome { decision, diagnostics }
+}
+
+/// Translate a diagnostic into a `console_*!` log line. The `counter=` prefix
+/// is load-bearing: ops dashboards grep for it to build per-counter alerts.
+fn emit_diagnostic(diag: &RateLimitDiagnostic) {
+    match diag {
+        RateLimitDiagnostic::KvGet { key, err } => {
+            console_warn!(
+                "[rate_limit] counter=rate_limit_kv_get_error key={} err={} (fail-open)",
+                key,
+                err
+            );
+        }
+        RateLimitDiagnostic::Deser { key, err } => {
+            console_error!(
+                "[rate_limit] counter=rate_limit_deser_error key={} err={} (overwriting on next write)",
+                key,
+                err
+            );
+        }
+        RateLimitDiagnostic::KvPut { key, err } => {
+            console_warn!(
+                "[rate_limit] counter=rate_limit_kv_put_error key={} err={} (fail-open)",
+                key,
+                err
+            );
+        }
+    }
 }

--- a/backend-rust/src/rate_limit.rs
+++ b/backend-rust/src/rate_limit.rs
@@ -6,6 +6,17 @@
 use serde::{Deserialize, Serialize};
 use worker::*;
 
+/// Default rate-limit ladder: 5 requests per 60-second window.
+/// See ADR-0011 §"Rate-limit ladder" for rationale.
+pub const DEFAULT_MAX_REQUESTS: u32 = 5;
+pub const DEFAULT_WINDOW_SECONDS: u64 = 60;
+
+/// Stricter ladder for registration endpoints: 3 requests per
+/// 300-second (5-minute) window. See ADR-0011 §"Rate-limit ladder"
+/// for why registration tolerates fewer attempts per window.
+pub const REGISTRATION_MAX_REQUESTS: u32 = 3;
+pub const REGISTRATION_WINDOW_SECONDS: u64 = 300;
+
 /// Rate limit configuration
 pub struct RateLimitConfig {
     /// Maximum requests per window
@@ -17,8 +28,8 @@ pub struct RateLimitConfig {
 impl Default for RateLimitConfig {
     fn default() -> Self {
         Self {
-            max_requests: 5,
-            window_seconds: 60,
+            max_requests: DEFAULT_MAX_REQUESTS,
+            window_seconds: DEFAULT_WINDOW_SECONDS,
         }
     }
 }

--- a/backend-rust/src/routes.rs
+++ b/backend-rust/src/routes.rs
@@ -79,7 +79,8 @@ pub struct LoginStartRequest {
 /// - `loginResponse` (Rust: `login_response`): base64-encoded opaque-ke `CredentialResponse` blob.
 /// - `stateKey` (Rust: `state_key`): opaque server-state handle (plain string, no base64) the
 ///   client must echo back on login/finish. Encodes a fake-vs-real record
-///   discriminator per RFC 9807 §10.9; server-managed, TTL 60s.
+///   discriminator per RFC 9807 §10.9; server-managed, TTL
+///   `LOGIN_STATE_TTL_SECONDS`.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LoginStartResponse {

--- a/backend-rust/src/routes.rs
+++ b/backend-rust/src/routes.rs
@@ -4,6 +4,11 @@ use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use serde::{Deserialize, Serialize};
 use worker::*;
 
+/// TTL for OPAQUE server-state KV entries.
+/// The duration equals one default rate-limit window; see ADR-0011
+/// §"Server-side fake-record TTL" for why this matches RFC 9807 §10.9.
+const LOGIN_STATE_TTL_SECONDS: u64 = 60;
+
 // Request/Response types
 //
 // These DTOs define the HTTP wire contract between the iOS
@@ -355,8 +360,8 @@ pub async fn handle_login_start(
         }
     };
 
-    // Store server state temporarily (60 second TTL)
-    // State key includes record type (f=fake, r=real) for finish step
+    // Store server state temporarily.
+    // State key includes record type (f=fake, r=real) for finish step.
     let login_states = env.kv("LOGIN_STATES")?;
     let state_key = format!(
         "state:{}:{}:{}",
@@ -367,7 +372,7 @@ pub async fn handle_login_start(
 
     login_states
         .put(&state_key, BASE64.encode(&result.state))?
-        .expiration_ttl(60)
+        .expiration_ttl(LOGIN_STATE_TTL_SECONDS)
         .execute()
         .await?;
 

--- a/backend-rust/src/routes.rs
+++ b/backend-rust/src/routes.rs
@@ -1,5 +1,5 @@
 use crate::opaque;
-use crate::rate_limit::{check_rate_limit, RateLimitConfig};
+use crate::rate_limit::{check_rate_limit, RateLimitConfig, REGISTRATION_MAX_REQUESTS, REGISTRATION_WINDOW_SECONDS};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use serde::{Deserialize, Serialize};
 use worker::*;
@@ -168,8 +168,8 @@ pub async fn handle_register_start(
     // Rate limiting per client_identifier
     if let Ok(rate_limits) = env.kv("RATE_LIMITS") {
         let config = RateLimitConfig {
-            max_requests: 3,     // Stricter for registration
-            window_seconds: 300, // 5 minute window
+            max_requests: REGISTRATION_MAX_REQUESTS,
+            window_seconds: REGISTRATION_WINDOW_SECONDS,
         };
         if let Err(retry_after) =
             check_rate_limit(&rate_limits, &body.client_identifier, "register_start", &config).await

--- a/backend-rust/src/routes.rs
+++ b/backend-rust/src/routes.rs
@@ -79,8 +79,8 @@ pub struct LoginStartRequest {
 /// - `loginResponse` (Rust: `login_response`): base64-encoded opaque-ke `CredentialResponse` blob.
 /// - `stateKey` (Rust: `state_key`): opaque server-state handle (plain string, no base64) the
 ///   client must echo back on login/finish. Encodes a fake-vs-real record
-///   discriminator per RFC 9807 §10.9; server-managed, TTL
-///   `LOGIN_STATE_TTL_SECONDS`.
+///   discriminator per RFC 9807 §10.9; server-managed, TTL ~60s
+///   (server-side constant `LOGIN_STATE_TTL_SECONDS`).
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LoginStartResponse {

--- a/backend-rust/src/routes.rs
+++ b/backend-rust/src/routes.rs
@@ -5,8 +5,11 @@ use serde::{Deserialize, Serialize};
 use worker::*;
 
 /// TTL for OPAQUE server-state KV entries.
-/// The duration equals one default rate-limit window; see ADR-0011
-/// §"Server-side fake-record TTL" for why this matches RFC 9807 §10.9.
+/// Bounds the server-side fake-record lifetime per RFC 9807 §10.9 — must
+/// be ≥ the longest plausible client-side KE2 → KE3 round trip. See
+/// ADR-0011 §"Server-side fake-record TTL"; this value is independently
+/// tunable from the rate-limit windows, even when the numbers happen to
+/// match.
 const LOGIN_STATE_TTL_SECONDS: u64 = 60;
 
 // Request/Response types

--- a/backend-rust/tests/rate_limit_error_logging_test.rs
+++ b/backend-rust/tests/rate_limit_error_logging_test.rs
@@ -23,11 +23,8 @@
 //! `cargo test rate_limit_error_logging --features testing` picks it up).
 
 use recordwell_opaque_worker::rate_limit::{
-    check_rate_limit_inner, GetEntryResult, RateLimitConfig, RateLimitDiagnostic, RateLimitEntry, RateLimitStore,
+    check_rate_limit_inner, GetEntryResult, RateLimitConfig, RateLimitEntry, RateLimitFailure, RateLimitStore,
 };
-// `RateLimitEntry` is only used as the parameter type of `put_entry` in the
-// `RateLimitStore` impl below; the fake never constructs one because none
-// of the failure-mode tests need a `Found(entry)` read path.
 use std::cell::RefCell;
 
 /// Controllable fake KV store. Each operation can be scripted to return
@@ -41,12 +38,9 @@ struct FakeStore {
 
 enum FakeGetResult {
     Missing,
+    Found(RateLimitEntry),
     Undeserializable(String),
     Transport(String),
-    // No `Found` variant: the four failure-mode tests all start from
-    // empty-or-errored KV state. A `Found(entry)` path would exercise the
-    // happy-path window-increment logic, which is covered implicitly by the
-    // existing production code path and not by this observability suite.
 }
 
 enum FakePutResult {
@@ -74,6 +68,7 @@ impl RateLimitStore for FakeStore {
             .expect("FakeStore: get_entry called without a scripted result");
         match r {
             FakeGetResult::Missing => Ok(GetEntryResult::Missing),
+            FakeGetResult::Found(entry) => Ok(GetEntryResult::Found(entry)),
             FakeGetResult::Undeserializable(err) => Ok(GetEntryResult::Undeserializable(err)),
             FakeGetResult::Transport(err) => Err(err),
         }
@@ -114,11 +109,11 @@ fn block_on<F: std::future::Future>(fut: F) -> F::Output {
     let waker: Waker = Arc::new(NoopWaker).into();
     let mut ctx = Context::from_waker(&waker);
     let mut fut = Box::pin(fut);
-    loop {
-        match fut.as_mut().poll(&mut ctx) {
-            Poll::Ready(v) => return v,
-            Poll::Pending => continue,
-        }
+    match fut.as_mut().poll(&mut ctx) {
+        Poll::Ready(v) => v,
+        Poll::Pending => panic!(
+            "block_on: future returned Pending; this runner only supports sync futures — use a real async runtime if you need true async"
+        ),
     }
 }
 
@@ -157,7 +152,7 @@ fn rate_limit_error_logging_kv_get_error_emits_get_diagnostic_and_allows() {
     assert_eq!(outcome.decision, None, "fail-open on KV get error");
     assert_eq!(outcome.diagnostics.len(), 1, "exactly one diagnostic expected");
     match &outcome.diagnostics[0] {
-        RateLimitDiagnostic::KvGet { key, err } => {
+        RateLimitFailure::KvGet { key, err } => {
             assert_eq!(key, "rate:xyz:login");
             assert!(
                 err.contains("KV unreachable"),
@@ -184,7 +179,7 @@ fn rate_limit_error_logging_deser_error_emits_deser_diagnostic_and_allows() {
     assert_eq!(outcome.decision, None, "fail-open on deser error");
     assert_eq!(outcome.diagnostics.len(), 1, "exactly one diagnostic expected");
     match &outcome.diagnostics[0] {
-        RateLimitDiagnostic::Deser { key, err } => {
+        RateLimitFailure::Deser { key, err } => {
             assert_eq!(key, "rate:pq:register");
             assert!(err.contains("invalid type"), "must preserve serde error text");
         }
@@ -211,10 +206,66 @@ fn rate_limit_error_logging_kv_put_error_emits_put_diagnostic_and_allows() {
     assert_eq!(outcome.decision, None, "fail-open on KV put error");
     assert_eq!(outcome.diagnostics.len(), 1, "exactly one diagnostic expected");
     match &outcome.diagnostics[0] {
-        RateLimitDiagnostic::KvPut { key, err } => {
+        RateLimitFailure::KvPut { key, err } => {
             assert_eq!(key, "rate:lmn:login");
             assert!(err.contains("throttled"));
         }
         other => panic!("expected KvPut, got {other:?}"),
     }
+}
+
+#[test]
+fn rate_limit_error_logging_under_limit_increment_emits_no_failure() {
+    // Scenario: existing entry within its window, count below max. Expected:
+    // request allowed, exactly one put (the incremented entry), no failure
+    // diagnostics. Exercises the `Found(entry)` + `count < max_requests`
+    // control-flow branch that the failure-mode tests do not cover.
+    let config = default_config();
+    let now: u64 = 10_000;
+    let existing = RateLimitEntry::new_for_testing(config.max_requests - 1, now - 5);
+    let store = FakeStore::default()
+        .with_get(FakeGetResult::Found(existing))
+        .with_put(FakePutResult::Ok);
+
+    let outcome = block_on(check_rate_limit_inner(&store, "rate:uvw:login", now, &config));
+
+    assert_eq!(outcome.decision, None, "under-limit request must be allowed");
+    assert!(
+        outcome.diagnostics.is_empty(),
+        "happy-path increment must emit no failure diagnostics, got {:?}",
+        outcome.diagnostics
+    );
+    assert_eq!(*store.put_calls.borrow(), 1, "increment must persist the updated entry");
+}
+
+#[test]
+fn rate_limit_error_logging_at_limit_denial_emits_no_failure() {
+    // Scenario: existing entry within its window, count already at max.
+    // Expected: request denied with retry_after until window expiry, zero
+    // puts (early return), no failure diagnostics. Exercises the
+    // `Found(entry)` + `count >= max_requests` branch.
+    let config = default_config();
+    let window_start: u64 = 10_000;
+    let now: u64 = window_start + 10; // 10s into the window
+    let expected_retry_after = config.window_seconds - (now - window_start);
+    let existing = RateLimitEntry::new_for_testing(config.max_requests, window_start);
+    let store = FakeStore::default().with_get(FakeGetResult::Found(existing));
+
+    let outcome = block_on(check_rate_limit_inner(&store, "rate:rst:login", now, &config));
+
+    assert_eq!(
+        outcome.decision,
+        Some(expected_retry_after),
+        "at-limit request must be denied with retry_after until window expiry"
+    );
+    assert!(
+        outcome.diagnostics.is_empty(),
+        "denied request must emit no failure diagnostics, got {:?}",
+        outcome.diagnostics
+    );
+    assert_eq!(
+        *store.put_calls.borrow(),
+        0,
+        "denied request must not write (early return)"
+    );
 }

--- a/backend-rust/tests/rate_limit_error_logging_test.rs
+++ b/backend-rust/tests/rate_limit_error_logging_test.rs
@@ -1,0 +1,220 @@
+//! Integration tests for rate-limiter KV failure-mode observability.
+//!
+//! The rate limiter in `src/rate_limit.rs` fails open on every KV error but
+//! must emit three distinct diagnostics so operators can alert on them
+//! independently:
+//!
+//! - `rate_limit_kv_get_error`  — KV backend unavailable on read (warn).
+//! - `rate_limit_deser_error`   — stored bytes failed to deserialize (error).
+//! - `rate_limit_kv_put_error`  — KV backend unavailable on write (warn).
+//!
+//! Missing-key reads must NOT emit a diagnostic — they are the normal
+//! "start a fresh window" path.
+//!
+//! These tests drive the pure `check_rate_limit_inner` core with a
+//! controllable fake store. The `rate_limit` module is reachable because
+//! `src/lib.rs` makes it `pub` under the `testing` feature; in release
+//! builds it is private and these symbols are not part of the worker's
+//! public API. Control flow is unchanged by this PR: the limiter still
+//! fails open; the tests just pin the observability contract.
+//!
+//! Requires: `cargo test --features testing` (wired via `required-features`
+//! on the `[[test]]` entry in `backend-rust/Cargo.toml`, so a bare
+//! `cargo test rate_limit_error_logging --features testing` picks it up).
+
+use recordwell_opaque_worker::rate_limit::{
+    check_rate_limit_inner, GetEntryResult, RateLimitConfig, RateLimitDiagnostic, RateLimitEntry, RateLimitStore,
+};
+// `RateLimitEntry` is only used as the parameter type of `put_entry` in the
+// `RateLimitStore` impl below; the fake never constructs one because none
+// of the failure-mode tests need a `Found(entry)` read path.
+use std::cell::RefCell;
+
+/// Controllable fake KV store. Each operation can be scripted to return
+/// success-missing, success-found, deser-error, or transport error.
+#[derive(Default)]
+struct FakeStore {
+    get_result: RefCell<Option<FakeGetResult>>,
+    put_result: RefCell<Option<FakePutResult>>,
+    put_calls: RefCell<u32>,
+}
+
+enum FakeGetResult {
+    Missing,
+    Undeserializable(String),
+    Transport(String),
+    // No `Found` variant: the four failure-mode tests all start from
+    // empty-or-errored KV state. A `Found(entry)` path would exercise the
+    // happy-path window-increment logic, which is covered implicitly by the
+    // existing production code path and not by this observability suite.
+}
+
+enum FakePutResult {
+    Ok,
+    Transport(String),
+}
+
+impl FakeStore {
+    fn with_get(self, g: FakeGetResult) -> Self {
+        *self.get_result.borrow_mut() = Some(g);
+        self
+    }
+    fn with_put(self, p: FakePutResult) -> Self {
+        *self.put_result.borrow_mut() = Some(p);
+        self
+    }
+}
+
+impl RateLimitStore for FakeStore {
+    async fn get_entry(&self, _key: &str) -> std::result::Result<GetEntryResult, String> {
+        let r = self
+            .get_result
+            .borrow_mut()
+            .take()
+            .expect("FakeStore: get_entry called without a scripted result");
+        match r {
+            FakeGetResult::Missing => Ok(GetEntryResult::Missing),
+            FakeGetResult::Undeserializable(err) => Ok(GetEntryResult::Undeserializable(err)),
+            FakeGetResult::Transport(err) => Err(err),
+        }
+    }
+
+    async fn put_entry(
+        &self,
+        _key: &str,
+        _entry: &RateLimitEntry,
+        _ttl_seconds: u64,
+    ) -> std::result::Result<(), String> {
+        *self.put_calls.borrow_mut() += 1;
+        let r = self.put_result.borrow_mut().take().unwrap_or(FakePutResult::Ok);
+        match r {
+            FakePutResult::Ok => Ok(()),
+            FakePutResult::Transport(err) => Err(err),
+        }
+    }
+}
+
+fn default_config() -> RateLimitConfig {
+    RateLimitConfig::default()
+}
+
+/// Tiny async runner to drive `check_rate_limit_inner` without needing a
+/// full tokio runtime at test-time. The inner function uses only `async fn`
+/// in trait methods backed by our `RefCell` fake (no timers, no IO, no
+/// channels), so a trivial executor suffices: every poll either completes
+/// (all operations are synchronous on the fake) or we spin.
+fn block_on<F: std::future::Future>(fut: F) -> F::Output {
+    use std::sync::Arc;
+    use std::task::{Context, Poll, Wake, Waker};
+
+    struct NoopWaker;
+    impl Wake for NoopWaker {
+        fn wake(self: Arc<Self>) {}
+    }
+    let waker: Waker = Arc::new(NoopWaker).into();
+    let mut ctx = Context::from_waker(&waker);
+    let mut fut = Box::pin(fut);
+    loop {
+        match fut.as_mut().poll(&mut ctx) {
+            Poll::Ready(v) => return v,
+            Poll::Pending => continue,
+        }
+    }
+}
+
+#[test]
+fn rate_limit_error_logging_missing_key_emits_no_diagnostic() {
+    // Scenario: no existing entry in KV. Expected: fresh window (count=1),
+    // no diagnostic emitted, request allowed.
+    let store = FakeStore::default()
+        .with_get(FakeGetResult::Missing)
+        .with_put(FakePutResult::Ok);
+    let config = default_config();
+
+    let outcome = block_on(check_rate_limit_inner(&store, "rate:abc:login", 1_000, &config));
+
+    assert_eq!(outcome.decision, None, "missing key must allow the request");
+    assert!(
+        outcome.diagnostics.is_empty(),
+        "missing key is the normal fresh-window path — no diagnostic expected, got {:?}",
+        outcome.diagnostics
+    );
+    assert_eq!(*store.put_calls.borrow(), 1, "fresh window must write a new entry");
+}
+
+#[test]
+fn rate_limit_error_logging_kv_get_error_emits_get_diagnostic_and_allows() {
+    // Scenario: KV backend returns a transport error on read. Expected:
+    // kv_get_error diagnostic, fail-open (request allowed), fresh window
+    // written.
+    let store = FakeStore::default()
+        .with_get(FakeGetResult::Transport("KV unreachable".into()))
+        .with_put(FakePutResult::Ok);
+    let config = default_config();
+
+    let outcome = block_on(check_rate_limit_inner(&store, "rate:xyz:login", 2_000, &config));
+
+    assert_eq!(outcome.decision, None, "fail-open on KV get error");
+    assert_eq!(outcome.diagnostics.len(), 1, "exactly one diagnostic expected");
+    match &outcome.diagnostics[0] {
+        RateLimitDiagnostic::KvGet { key, err } => {
+            assert_eq!(key, "rate:xyz:login");
+            assert!(
+                err.contains("KV unreachable"),
+                "diagnostic must carry the underlying error message: {err}"
+            );
+        }
+        other => panic!("expected KvGet, got {other:?}"),
+    }
+}
+
+#[test]
+fn rate_limit_error_logging_deser_error_emits_deser_diagnostic_and_allows() {
+    // Scenario: stored bytes fail to deserialize (schema drift or poisoning).
+    // Expected: deser_error diagnostic, fail-open, fresh window written.
+    // Writing the fresh entry overwrites the poisoned bytes — this is the
+    // self-limiting property documented in ADR-0011.
+    let store = FakeStore::default()
+        .with_get(FakeGetResult::Undeserializable("invalid type: null".into()))
+        .with_put(FakePutResult::Ok);
+    let config = default_config();
+
+    let outcome = block_on(check_rate_limit_inner(&store, "rate:pq:register", 3_000, &config));
+
+    assert_eq!(outcome.decision, None, "fail-open on deser error");
+    assert_eq!(outcome.diagnostics.len(), 1, "exactly one diagnostic expected");
+    match &outcome.diagnostics[0] {
+        RateLimitDiagnostic::Deser { key, err } => {
+            assert_eq!(key, "rate:pq:register");
+            assert!(err.contains("invalid type"), "must preserve serde error text");
+        }
+        other => panic!("expected Deser, got {other:?}"),
+    }
+    assert_eq!(
+        *store.put_calls.borrow(),
+        1,
+        "self-limiting overwrite: must write a fresh entry after a poisoned read"
+    );
+}
+
+#[test]
+fn rate_limit_error_logging_kv_put_error_emits_put_diagnostic_and_allows() {
+    // Scenario: read succeeds (missing key) but write fails. Expected:
+    // kv_put_error diagnostic, fail-open (request allowed).
+    let store = FakeStore::default()
+        .with_get(FakeGetResult::Missing)
+        .with_put(FakePutResult::Transport("KV write throttled".into()));
+    let config = default_config();
+
+    let outcome = block_on(check_rate_limit_inner(&store, "rate:lmn:login", 4_000, &config));
+
+    assert_eq!(outcome.decision, None, "fail-open on KV put error");
+    assert_eq!(outcome.diagnostics.len(), 1, "exactly one diagnostic expected");
+    match &outcome.diagnostics[0] {
+        RateLimitDiagnostic::KvPut { key, err } => {
+            assert_eq!(key, "rate:lmn:login");
+            assert!(err.contains("throttled"));
+        }
+        other => panic!("expected KvPut, got {other:?}"),
+    }
+}

--- a/docs/adr/adr-0004-sync-encryption.md
+++ b/docs/adr/adr-0004-sync-encryption.md
@@ -215,6 +215,19 @@ We will implement a **recovery code-based multi-device system** with **last-writ
 - [BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki): Mnemonic code specification
 - [1Password Security Design](https://support.1password.com/secret-key-security/): Recovery code approach
 
+## Addendum: Document blob size cap (2026-04-18)
+
+`DocumentBlobService.maxFileSizeBytes` is currently **10 MB** (`10 * 1024 * 1024` bytes). This is a pragmatic local-storage cap — not a limit imposed by any underlying storage or crypto primitive. It bounds the in-memory cost of encrypting blobs and generating thumbnails, and keeps the on-disk footprint tractable for today's local-only deployment.
+
+### Revisit trigger
+
+When sync / replication work begins (this ADR's core subject), the per-blob size cap becomes a network/replication cost decision, not just a local-storage decision. At that point the limit must be re-evaluated:
+
+1. Keep 10 MB and document the decision in this ADR.
+2. Change it (larger or smaller) and update `DocumentBlobService.maxFileSizeBytes` alongside this ADR entry.
+
+Either way, the inline comment in `DocumentBlobService.swift` now points at this section rather than self-acknowledging an ADR gap.
+
 ---
 
 **Decision Date**: 2025-12-21

--- a/docs/adr/adr-0004-sync-encryption.md
+++ b/docs/adr/adr-0004-sync-encryption.md
@@ -215,6 +215,12 @@ We will implement a **recovery code-based multi-device system** with **last-writ
 - [BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki): Mnemonic code specification
 - [1Password Security Design](https://support.1password.com/secret-key-security/): Recovery code approach
 
+---
+
+**Decision Date**: 2025-12-21
+**Author**: Claude Code
+**Reviewers**: [To be assigned]
+
 ## Addendum: Document blob size cap (2026-04-18)
 
 `DocumentBlobService.maxFileSizeBytes` is currently **10 MB** (`10 * 1024 * 1024` bytes). This is a pragmatic local-storage cap — not a limit imposed by any underlying storage or crypto primitive. It bounds the in-memory cost of encrypting blobs and generating thumbnails, and keeps the on-disk footprint tractable for today's local-only deployment.
@@ -227,9 +233,3 @@ When sync / replication work begins (this ADR's core subject), the per-blob size
 2. Change it (larger or smaller) and update `DocumentBlobService.maxFileSizeBytes` alongside this ADR entry.
 
 Either way, the inline comment in `DocumentBlobService.swift` now points at this section rather than self-acknowledging an ADR gap.
-
----
-
-**Decision Date**: 2025-12-21
-**Author**: Claude Code
-**Reviewers**: [To be assigned]

--- a/docs/adr/adr-0011-opaque-zero-knowledge-auth.md
+++ b/docs/adr/adr-0011-opaque-zero-knowledge-auth.md
@@ -286,7 +286,7 @@ The read path emits three distinct counters (as structured `console_*!` log line
 - `rate_limit_deser_error` — stored entry failed to deserialize. **Expected to be flat zero in normal operation.** A non-zero rate indicates either a schema migration is in flight without a corresponding read-side migration, or an active attempt to poison a rate-limit key. Severity: error. Alert immediately.
 - `rate_limit_kv_put_error` — KV backend unavailable on write. Same class as `kv_get_error`. Severity: warn.
 
-The write path emits `rate_limit_kv_put_error` for the single put site (the read-then-write has exactly one `put_entry` call regardless of whether the window is new or incremented).
+The write path emits `rate_limit_kv_put_error` for the single put site. When the request is allowed (new window or incremented count), there is exactly one `put_entry` call; a denied request short-circuits with zero puts.
 
 ### Alerting contract
 

--- a/docs/adr/adr-0011-opaque-zero-knowledge-auth.md
+++ b/docs/adr/adr-0011-opaque-zero-knowledge-auth.md
@@ -267,3 +267,28 @@ Five minutes was chosen because:
 ### Tunability contract
 
 The 300s value is a tunable, not a constant. If user research or a compliance requirement shifts the balance, update this section and the `LockStateService.defaultTimeout` value together.
+
+## Addendum: Rate-limiter fail-open policy and alerting contract (2026-04-18)
+
+**Policy:** the rate limiter in `backend-rust/src/rate_limit.rs` fails open on KV-backend errors. A failure to read or write the counter entry allows the request through rather than blocking it.
+
+**Rationale.** Cloudflare's edge network (the pre-application layer) is the primary defence against L3/L4 floods.
+Application-level rate limiting exists to tame *correlated* high-effort attacks — repeated OPAQUE-handshake attempts from the same client identifier.
+If the KV backend is degraded enough that rate-limit counters are unavailable, auth flows that depend on KV (`CREDENTIALS`, `LOGIN_STATES`, `BUNDLES`) are also degraded, so the rate-limiter's fail-open stance does not widen the attacker's actual window.
+
+**Self-limiting property.** When a stored rate-limit entry fails to deserialize (possible causes: schema migration, byte poisoning via a bug elsewhere), the read path treats it as `None` → fresh window → `count=1` → the next write overwrites the poisoned bytes with well-formed JSON. The attacker's payoff is *exactly one extra allowed request* for the affected client identifier, after which normal accounting resumes.
+
+### Failure-mode taxonomy and counters
+
+The read path emits three distinct counters (as structured `console_*!` log lines with a `counter=` prefix; ops dashboards grep this prefix to build per-counter alerts):
+
+- `rate_limit_kv_get_error` — KV backend unavailable (transient). Expected to be near-zero in normal operation; bursts indicate a Cloudflare KV incident. Severity: warn.
+- `rate_limit_deser_error` — stored entry failed to deserialize. **Expected to be flat zero in normal operation.** A non-zero rate indicates either a schema migration is in flight without a corresponding read-side migration, or an active attempt to poison a rate-limit key. Severity: error. Alert immediately.
+- `rate_limit_kv_put_error` — KV backend unavailable on write. Same class as `kv_get_error`. Severity: warn.
+
+The write path emits `rate_limit_kv_put_error` for the single put site (the read-then-write has exactly one `put_entry` call regardless of whether the window is new or incremented).
+
+### Alerting contract
+
+- `rate_limit_deser_error > 0` over any 5-minute window → page oncall.
+- `rate_limit_kv_get_error` or `rate_limit_kv_put_error` sustained > 10/min for 5 minutes → alert (indicates KV incident).

--- a/docs/adr/adr-0011-opaque-zero-knowledge-auth.md
+++ b/docs/adr/adr-0011-opaque-zero-knowledge-auth.md
@@ -262,7 +262,7 @@ Five minutes was chosen because:
 
 1. The primary threat model (ADR-0001) treats the device as a soft-trust boundary — the OS screen lock is the first line of defence and its lifetime is user-controlled.
 2. The OPAQUE primary passphrase is relatively expensive to re-enter (12+ chars); forcing re-entry every 60s materially degrades session-continuity for common flows like "photograph three bottles, then annotate them."
-3. Users with higher risk tolerance can configure their own OS screen-lock to be shorter; the app respects `WillResignActive` and `DidEnterBackground` immediately rather than relying on its own timer for those transitions.
+3. The 300s timer protects only the *background-time* gap. The app locks immediately on `WillResignActive` / `DidEnterBackground`, so the timer is not guarding the foreground-but-unattended case — that threat is covered by the device's own OS screen lock, whose lifetime is user-controlled and which users with a stricter risk tolerance can tighten independently of this default.
 
 ### Tunability contract
 

--- a/docs/adr/adr-0011-opaque-zero-knowledge-auth.md
+++ b/docs/adr/adr-0011-opaque-zero-knowledge-auth.md
@@ -240,3 +240,7 @@ This client ladder defends against a stranger with the physical device; the serv
 ### What to change together
 
 Any change to `DEFAULT_MAX_REQUESTS` / `DEFAULT_WINDOW_SECONDS` / `REGISTRATION_MAX_REQUESTS` / `REGISTRATION_WINDOW_SECONDS` must be reflected in this addendum and cross-checked against the client-side ladder in `AuthenticationService.swift`.
+
+### Server-side fake-record TTL
+
+Per RFC 9807 §10.9, the server must synthesise a deterministic fake login envelope on username miss to prevent timing / structure-based account enumeration. The fake-record state is stored in the `LOGIN_STATES` KV namespace and evicted after `LOGIN_STATE_TTL_SECONDS` (currently 60). This window must be ≥ the longest plausible client-side KE2 → KE3 round trip; 60s is deliberately generous.

--- a/docs/adr/adr-0011-opaque-zero-knowledge-auth.md
+++ b/docs/adr/adr-0011-opaque-zero-knowledge-auth.md
@@ -237,10 +237,12 @@ The iOS client applies its own escalating device-lockout ladder in `Authenticati
 
 This client ladder defends against a stranger with the physical device; the server ladder defends against a remote attacker burning credentials against the API. The two layers are deliberately independent — a client that bypasses or reinstalls past the device-lockout still hits the server ceiling before causing persistent damage.
 
-### What to change together
-
-Any change to `DEFAULT_MAX_REQUESTS` / `DEFAULT_WINDOW_SECONDS` / `REGISTRATION_MAX_REQUESTS` / `REGISTRATION_WINDOW_SECONDS` must be reflected in this addendum and cross-checked against the client-side ladder in `AuthenticationService.swift`.
-
 ### Server-side fake-record TTL
 
 Per RFC 9807 §10.9, the server must synthesise a deterministic fake login envelope on username miss to prevent timing / structure-based account enumeration. The fake-record state is stored in the `LOGIN_STATES` KV namespace and evicted after `LOGIN_STATE_TTL_SECONDS` (currently 60). This window must be ≥ the longest plausible client-side KE2 → KE3 round trip; 60s is deliberately generous.
+
+The current value coincidentally equals `DEFAULT_WINDOW_SECONDS`. The equality is convenient but not semantic — retune independently.
+
+### What to change together
+
+Any change to `DEFAULT_MAX_REQUESTS` / `DEFAULT_WINDOW_SECONDS` / `REGISTRATION_MAX_REQUESTS` / `REGISTRATION_WINDOW_SECONDS` / `LOGIN_STATE_TTL_SECONDS` must be reflected in this addendum and cross-checked against the client-side ladder in `AuthenticationService.swift`.

--- a/docs/adr/adr-0011-opaque-zero-knowledge-auth.md
+++ b/docs/adr/adr-0011-opaque-zero-knowledge-auth.md
@@ -246,3 +246,24 @@ The current value coincidentally equals `DEFAULT_WINDOW_SECONDS`. The equality i
 ### What to change together
 
 Any change to `DEFAULT_MAX_REQUESTS` / `DEFAULT_WINDOW_SECONDS` / `REGISTRATION_MAX_REQUESTS` / `REGISTRATION_WINDOW_SECONDS` / `LOGIN_STATE_TTL_SECONDS` must be reflected in this addendum and cross-checked against the client-side ladder in `AuthenticationService.swift`.
+
+## Addendum: Session / auto-lock lifetime (2026-04-18)
+
+Default auto-lock timeout: **300 seconds (5 minutes)** (see `LockStateService.defaultTimeout`).
+
+### Rationale
+
+A medical-records app sits between two typical mobile timeout points:
+
+- Banking apps often auto-lock after 60–120 seconds — a strong security stance but a high interruption rate for short, task-focused sessions.
+- General-purpose apps commonly leave lock-state to the device's own OS screen lock (often 5 minutes), relying on the device passcode as the fallback.
+
+Five minutes was chosen because:
+
+1. The primary threat model (ADR-0001) treats the device as a soft-trust boundary — the OS screen lock is the first line of defence and its lifetime is user-controlled.
+2. The OPAQUE primary passphrase is relatively expensive to re-enter (12+ chars); forcing re-entry every 60s materially degrades session-continuity for common flows like "photograph three bottles, then annotate them."
+3. Users with higher risk tolerance can configure their own OS screen-lock to be shorter; the app respects `WillResignActive` and `DidEnterBackground` immediately rather than relying on its own timer for those transitions.
+
+### Tunability contract
+
+The 300s value is a tunable, not a constant. If user research or a compliance requirement shifts the balance, update this section and the `LockStateService.defaultTimeout` value together.

--- a/docs/adr/adr-0011-opaque-zero-knowledge-auth.md
+++ b/docs/adr/adr-0011-opaque-zero-knowledge-auth.md
@@ -214,3 +214,29 @@ OPAQUE intentionally provides no indication of whether username or password is w
 **Decision Date**: 2026-01-28
 **Author**: Claude Code
 **Reviewers**: [To be assigned]
+
+## Addendum: Rate-limit ladder (2026-04-18)
+
+The OPAQUE auth endpoints use a two-tier rate-limit ladder.
+
+### Server-side defaults
+
+All endpoints (`backend-rust/src/rate_limit.rs`):
+
+- **Default ladder:** 5 requests per 60-second window (`DEFAULT_MAX_REQUESTS`, `DEFAULT_WINDOW_SECONDS`). Applied to `/login/start` (and any future endpoint that calls `RateLimitConfig::default()`).
+- **Registration ladder** (applied to `/register/start`): 3 requests per 300-second (5-minute) window (`REGISTRATION_MAX_REQUESTS`, `REGISTRATION_WINDOW_SECONDS`). Rationale: the registration handshake creates durable state (envelope storage, key-material derivation) per attempt, so the cost of tolerating a high attempt rate is meaningfully higher than for login.
+
+### Client-side back-off
+
+The iOS client applies its own escalating device-lockout ladder in `AuthenticationService.swift` (`rateLimitThresholds`) after consecutive failed unlock attempts, before touching the server:
+
+- 3 failures → 30-second lockout
+- 4 failures → 60 seconds
+- 5 failures → 300 seconds
+- 6+ failures → 900 seconds
+
+This client ladder defends against a stranger with the physical device; the server ladder defends against a remote attacker burning credentials against the API. The two layers are deliberately independent — a client that bypasses or reinstalls past the device-lockout still hits the server ceiling before causing persistent damage.
+
+### What to change together
+
+Any change to `DEFAULT_MAX_REQUESTS` / `DEFAULT_WINDOW_SECONDS` / `REGISTRATION_MAX_REQUESTS` / `REGISTRATION_WINDOW_SECONDS` must be reflected in this addendum and cross-checked against the client-side ladder in `AuthenticationService.swift`.

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Models/Backup/BackupFile.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Models/Backup/BackupFile.swift
@@ -149,7 +149,7 @@ struct BackupKDF: Codable, Equatable {
     /// Default Argon2id parameters for the backup KDF.
     ///
     /// Values are pinned to ADR-0002 §"Argon2id Parameters" and enforced by
-    /// `BackupKDFParametersTest`; that test will fail if either the ADR or
+    /// `BackupKDFParametersTests`; that test will fail if either the ADR or
     /// these constants drift without the other being updated.
     static var defaultArgon2id: BackupKDF {
         BackupKDF(

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Models/Backup/BackupFile.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Models/Backup/BackupFile.swift
@@ -146,7 +146,11 @@ struct BackupKDF: Codable, Equatable {
     /// Output key length in bytes
     let keyLength: Int
 
-    /// Default Argon2id parameters matching ADR-0002
+    /// Default Argon2id parameters for the backup KDF.
+    ///
+    /// Values are pinned to ADR-0002 §"Argon2id Parameters" and enforced by
+    /// `BackupKDFParametersTest`; that test will fail if either the ADR or
+    /// these constants drift without the other being updated.
     static var defaultArgon2id: BackupKDF {
         BackupKDF(
             algorithm: "Argon2id",

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Auth/LockStateService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Auth/LockStateService.swift
@@ -35,21 +35,14 @@ final class LockStateService: LockStateServiceProtocol {
     private static let lockTimeoutKey = "com.family-medical-app.lock-timeout"
     private static let demoModeKey = "com.family-medical-app.demo-mode"
 
-    /// Default auto-lock timeout: 300 seconds (5 minutes) of background time.
+    /// Default auto-lock timeout in seconds.
     ///
-    /// Threat model: an unattended device left in a pocket, bag, or on a desk
-    /// is the dominant compromise scenario for a mobile medical-records app.
-    /// A short auto-lock window trades a small UX cost (re-auth after a coffee
-    /// break) for a substantially reduced surface area to a stranger who picks
-    /// up the device while it's unlocked.
+    /// See ADR-0011 §"Session / auto-lock lifetime" for the 5-minute
+    /// rationale and the tunability contract.
     ///
     /// Override path: `lockTimeoutSeconds` on `LockStateServiceProtocol` is
     /// persisted to `UserDefaults` and may be set programmatically. No settings
     /// UI binds to this value today.
-    ///
-    /// No Phase-0 ADR currently captures session-lifetime rationale; this
-    /// default should be lifted into an ADR addendum (or a new ADR) when the
-    /// session-management story is formalised.
     private static let defaultTimeout = 300 // 5 minutes
 
     // MARK: - Properties

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentBlobService.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/Services/Document/DocumentBlobService.swift
@@ -87,8 +87,10 @@ actor DocumentBlobService: DocumentBlobServiceProtocol {
     ///
     /// Rationale: bounds the in-memory cost of encrypting blobs and generating
     /// thumbnails, and keeps the on-disk footprint and eventual sync-payload size
-    /// tractable. No ADR pins this value; it is a pragmatic cap that should be
-    /// revisited when sync lands and real-world payload distributions are known.
+    /// tractable. See ADR-0004 §"Addendum: Document blob size cap" for the
+    /// revisit contract: when sync / replication lands, this value must be
+    /// re-evaluated and either kept (with rationale) or changed (alongside an
+    /// updated ADR entry).
     static let maxFileSizeBytes = 10 * 1_024 * 1_024
 
     /// Target maximum edge length of generated thumbnails: 200 px.

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/ViewModels/Documents/DocumentPickerViewModel.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/ViewModels/Documents/DocumentPickerViewModel.swift
@@ -56,7 +56,23 @@ final class DocumentPickerViewModel {
 
     // MARK: - Constants
 
-    /// Maximum drafts per record.
+    /// Maximum number of document drafts a user can stage against a single
+    /// parent record before the picker refuses new entries.
+    ///
+    /// Five is a product/UX cap, not a technical limit. It is sized to cover
+    /// the realistic cases we expect in this app — a few pages of lab
+    /// results, a medication-bottle photo set captured from multiple angles,
+    /// or a primary document paired with an annotation — while keeping the
+    /// per-record cost bounded. The worst-case on-disk/in-envelope footprint
+    /// for one record is `maxPerRecord * DocumentBlobService.maxFileSizeBytes`,
+    /// so this value must be tuned in conjunction with that cap, never in
+    /// isolation.
+    ///
+    /// No ADR currently pins this value. When the driver changes — e.g. sync
+    /// batching quantising attachment payloads, attachment re-encryption
+    /// cost on key rotation, or a UI affordance that makes larger sets
+    /// browseable — update this comment and cross-reference whichever ADR
+    /// captures the new rationale.
     static let maxPerRecord: Int = 5
 
     // MARK: - Types

--- a/ios/FamilyMedicalApp/FamilyMedicalApp/ViewModels/Documents/DocumentPickerViewModel.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalApp/ViewModels/Documents/DocumentPickerViewModel.swift
@@ -71,7 +71,7 @@ final class DocumentPickerViewModel {
     /// No ADR currently pins this value. When the driver changes — e.g. sync
     /// batching quantising attachment payloads, attachment re-encryption
     /// cost on key rotation, or a UI affordance that makes larger sets
-    /// browseable — update this comment and cross-reference whichever ADR
+    /// browsable — update this comment and cross-reference whichever ADR
     /// captures the new rationale.
     static let maxPerRecord: Int = 5
 

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Models/Backup/BackupKDFParametersTest.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Models/Backup/BackupKDFParametersTest.swift
@@ -1,0 +1,25 @@
+import Testing
+@testable import FamilyMedicalApp
+
+/// Pins `BackupKDF.defaultArgon2id` to ADR-0002 §"Argon2id Parameters".
+///
+/// If either the ADR or the implementation drifts without the other, this
+/// test fails. The constants below ARE the source of truth for this
+/// assertion; any change MUST be reflected in
+/// `docs/adr/adr-0002-key-hierarchy.md` first.
+struct BackupKDFParametersTest {
+    // Pinned to ADR-0002. Update together.
+    private static let adr0002Memory: Int = 64 * 1_024 * 1_024 // 64 MB = 67,108,864 bytes
+    private static let adr0002Iterations: Int = 3
+    private static let adr0002Parallelism: Int = 1
+    private static let adr0002KeyLength: Int = 32 // 256-bit key
+
+    @Test
+    func defaultArgon2idMatchesADR0002() {
+        let kdf = BackupKDF.defaultArgon2id
+        #expect(kdf.memory == Self.adr0002Memory)
+        #expect(kdf.iterations == Self.adr0002Iterations)
+        #expect(kdf.parallelism == Self.adr0002Parallelism)
+        #expect(kdf.keyLength == Self.adr0002KeyLength)
+    }
+}

--- a/ios/FamilyMedicalApp/FamilyMedicalAppTests/Models/Backup/BackupKDFParametersTests.swift
+++ b/ios/FamilyMedicalApp/FamilyMedicalAppTests/Models/Backup/BackupKDFParametersTests.swift
@@ -7,7 +7,7 @@ import Testing
 /// test fails. The constants below ARE the source of truth for this
 /// assertion; any change MUST be reflected in
 /// `docs/adr/adr-0002-key-hierarchy.md` first.
-struct BackupKDFParametersTest {
+struct BackupKDFParametersTests {
     // Pinned to ADR-0002. Update together.
     private static let adr0002Memory: Int = 64 * 1_024 * 1_024 // 64 MB = 67,108,864 bytes
     private static let adr0002Iterations: Int = 3


### PR DESCRIPTION
## Summary

Day-1 review PR 4 of 7 — documents the hidden defaults identified in [`docs/day-1-review/2026-04-18-detailed-report.md`](docs/day-1-review/2026-04-18-detailed-report.md) findings 10, 11, 12, 13, 14, 15, 31, 36.

- Names eight previously-bare numeric constants (`DEFAULT_MAX_REQUESTS`, `DEFAULT_WINDOW_SECONDS`, `REGISTRATION_MAX_REQUESTS`, `REGISTRATION_WINDOW_SECONDS`, `LOGIN_STATE_TTL_SECONDS`, `CORS_PREFLIGHT_MAX_AGE_SECONDS`) with cross-links to ADR-0011 / ADR-0002 / ADR-0004.
- Four new ADR addenda (all dated 2026-04-18):
  - **ADR-0011 §Addendum: Rate-limit ladder** — two-tier server ladder + iOS client-side device-lockout ladder + change-together contract (covers server-side fake-record TTL as a nested subsection).
  - **ADR-0011 §Addendum: Session / auto-lock lifetime** — rationale for the 5-minute `LockStateService.defaultTimeout` default + tunability contract.
  - **ADR-0011 §Addendum: Rate-limiter fail-open policy and alerting contract** — documents the fail-open stance, the self-limiting overwrite property for deser failures, and the alerting contract for the new counters. Closes #176.
  - **ADR-0004 §Addendum: Document blob size cap** — pins the 10 MB `DocumentBlobService.maxFileSizeBytes` revisit to the sync/replication-landing milestone.
- Splits the rate-limiter KV failure modes (previously collapsed into one `.unwrap_or_default()`) into three distinct `console_*!` counters + severities — `rate_limit_kv_get_error` (warn, KV outage), `rate_limit_deser_error` (error, schema drift / poisoning), `rate_limit_kv_put_error` (warn, KV outage on write). Control flow is unchanged (still fails open). 6 new integration tests cover all error branches plus under-limit and at-limit decision paths.
- New unit test `BackupKDFParametersTests.defaultArgon2idMatchesADR0002` pins the Argon2id params on `BackupKDF.defaultArgon2id` literally to ADR-0002 — fails immediately on drift in either direction.
- `DocumentPickerViewModel.maxPerRecord` gets a multi-paragraph rationale doc matching the `DocumentBlobService.maxFileSizeBytes` style (no value change).

### Prerequisite (Task 0)

Removes the global `[build] target = "wasm32-unknown-unknown"` pin from `backend-rust/.cargo/config.toml` so native `cargo test` runs against the host triple. This unblocks the 6 integration tests in Task 7 (they need to exercise failure-mode counters at build time, not only at deploy time via `smoke_test.sh`). `worker-build` and `wrangler` still pass `--target wasm32-unknown-unknown` explicitly, so the deploy chain is unaffected. `SETUP.md` updated accordingly.

### Scope adjustments

- **Finding 13 (Path B, not Path A):** the plan offered either (A) file a GitHub issue for the maxFileSizeBytes revisit, or (B) write an ADR addendum. I used Path B because this branch was prepared locally without GitHub write access during execution. If you want an issue too, filing one post-merge and editing the inline comment to add the issue link would be a one-line follow-up.

### Closes

- #176 — rate-limiter fail-open observability gap.

## Follow-ups (out of scope for this PR)

- `scripts/run-tests.sh` line 40 unconditionally sets `DESTINATION=""`, clobbering any env var the caller exported — so the `DESTINATION=... scripts/run-tests.sh` form silently fails the `:${DESTINATION:?...}` assertion on line 104 (the `--destination` flag must be used instead). Minor DX papercut; should be a 1-line fix to make the init conditional (`DESTINATION="${DESTINATION:-}"`).
- `backend-rust/src/lib.rs` — `cors_preflight()` does not set `Access-Control-Allow-Origin` (relies on `build_response_headers`) and `Access-Control-Allow-Headers` does not include `Authorization`. Worth auditing against actual iOS client headers separately.
- ADR-0011's three addenda interleave rate-limit ladder → session/auto-lock → rate-limiter fail-open, which reads slightly non-linearly (the two rate-limit pieces aren't adjacent). Append-only ADR convention means this can't be reordered without history rewrite; future addenda should group related topics at write time.

## Test plan

- [x] `cargo test` — native unit/integration tests pass (0/0/0 baseline; 6/0/0 with `--features testing rate_limit_error_logging`).
- [x] `cargo build --target wasm32-unknown-unknown --release` — wasm deploy chain unaffected.
- [x] `cargo clippy --all-targets --features testing -- -D warnings` — clean.
- [x] `scripts/run-tests.sh --destination '...'` — final iOS suite matches baseline pass set + adds `BackupKDFParametersTests.defaultArgon2idMatchesADR0002`.
- [x] `scripts/check-coverage.sh` — at or above 85% overall and per-file (with pre-existing exceptions).
- [x] `pre-commit run --all-files` — clean.

## Summary by Sourcery

Document previously implicit backend and iOS security-related defaults, and add observability and tests around the rate limiter and cryptographic/session parameters.

Enhancements:
- Introduce named rate-limiter and CORS max-age constants and make the login-state TTL explicit, keeping behavior unchanged while clarifying configuration intent.
- Refactor the rate limiter to surface distinct KV failure diagnostics while still failing open, and expose its core logic behind a test-only feature for native integration testing.

Build:
- Enable building the Rust backend as both cdylib and rlib and configure a test-only feature to support integration tests, while allowing `cargo test` to run natively by unpinning the global wasm32 build target.

Documentation:
- Record server-side rate-limit ladders, fake login-state TTL, session auto-lock lifetime, and document blob size cap in ADR-0011 and ADR-0004, and align code comments to those ADRs.

Tests:
- Add Rust integration tests that pin rate-limiter error logging behavior and decision paths, and a Swift test that pins backup Argon2id KDF parameters to ADR-0002.

Chores:
- Update backend setup documentation to describe native testing flows and adjust references to the smoke-test harness.